### PR TITLE
Change Visual Studio Build Tools link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Users of this software are expected to use this software responsibly while abidi
 -   pip
 -   git
 -   [ffmpeg](https://www.youtube.com/watch?v=OlNWCpFdVMA) 
--   [visual studio 2022 runtimes (windows)](https://learn.microsoft.com/en-us/visualstudio/releases/2022/redistribution#vs2022-download)
+-   [visual studio 2022 runtimes (windows)](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
 #### 2. Clone Repository
     https://github.com/hacksider/Deep-Live-Cam.git
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the README.md file to change the link for Visual Studio 2022 runtimes, directing users to the Visual C++ Build Tools page instead of the previous redistribution page.

- **Documentation**:
    - Updated the link for Visual Studio 2022 runtimes in the README.md file to point to the Visual C++ Build Tools page.

<!-- Generated by sourcery-ai[bot]: end summary -->