### PR TITLE
Fix face_enhancer issues

### DIFF
--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -25,6 +25,7 @@ def load_frame_processor_module(frame_processor: str) -> Any:
             if not hasattr(frame_processor_module, method_name):
                 sys.exit()
     except ImportError:
+        print(f"Frame processor {frame_processor} not found")
         sys.exit()
     return frame_processor_module
 
@@ -47,8 +48,8 @@ def set_frame_processors_modules_from_ui(frame_processors: List[str]) -> None:
             FRAME_PROCESSORS_MODULES.append(frame_processor_module)
             modules.globals.frame_processors.append(frame_processor)
         if state == False:
-            frame_processor_module = load_frame_processor_module(frame_processor)
             try:
+                frame_processor_module = load_frame_processor_module(frame_processor)
                 FRAME_PROCESSORS_MODULES.remove(frame_processor_module)
                 modules.globals.frame_processors.remove(frame_processor)
             except:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 
-numpy==1.23.5
+numpy==1.24.3
 opencv-python==4.8.1.78
 onnx==1.16.0
 insightface==0.7.3
@@ -13,11 +13,11 @@ torch==2.0.1; sys_platform == 'darwin'
 torchvision==0.15.2+cu118; sys_platform != 'darwin'
 torchvision==0.15.2; sys_platform == 'darwin'
 onnxruntime==1.18.0; sys_platform == 'darwin' and platform_machine != 'arm64'
-onnxruntime-silicon==1.13.1; sys_platform == 'darwin' and platform_machine == 'arm64'
+onnxruntime-silicon==1.16.3; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.18.0; sys_platform != 'darwin'
 tensorflow==2.13.0rc1; sys_platform == 'darwin'
 tensorflow==2.12.0; sys_platform != 'darwin'
 opennsfw2==0.10.2
 protobuf==4.23.2
 tqdm==4.66.4
-gfpgan==1.3.6
+gfpgan==1.3.8


### PR DESCRIPTION
Updates to `gfpgan==1.3.8` to fix issues with loading `face_enhancer` on OS X Apple Silicon.

Also moves retrieval of modules to remove inside the try-catch block.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses issues with loading the `face_enhancer` module on OS X Apple Silicon by updating the `gfpgan` dependency to version 1.3.8. Additionally, it enhances error handling by adding a print statement when a frame processor module is not found and refactors the code to move module retrieval inside the try-catch block.

- **Bug Fixes**:
    - Fixed issues with loading `face_enhancer` on OS X Apple Silicon by updating `gfpgan` to version 1.3.8.
- **Enhancements**:
    - Added a print statement to provide feedback when a frame processor module is not found.

<!-- Generated by sourcery-ai[bot]: end summary -->