### PR TITLE
Fix this cyclic dependency issue which was coming while installing rquirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 .tmp/
 temp/
 venv/
+env/
 workflow/
 gfpgan/
 models/inswapper_128.onnx


### PR DESCRIPTION
I have updated the requirements.txt. 
This should be able to get your requirements installed without any major cyclic dependency error. It is working fine for me; 
I have tested it only on Windows.

Use a virtual environment to set this up.


![image](https://github.com/user-attachments/assets/4067c088-6365-4c78-acf7-9c0d9605ad80)


