### PR TITLE
Update README.md fixed directml command "directml" to "dml"

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pip install onnxruntime-directml==1.15.1
 2.  Usage in case the provider is available:
 
 ```
-python run.py --execution-provider directml
+python run.py --execution-provider dml
 
 ```
 


### PR DESCRIPTION
In the latest version, it should be "dml".

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the README.md to reflect the correct command for the execution provider, changing 'directml' to 'dml'.

Documentation:
- Correct the command in the README.md to use 'dml' instead of 'directml' for the execution provider.

<!-- Generated by sourcery-ai[bot]: end summary -->