### PR TITLE
Update onnxruntime-gpu version in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ pip install -r requirements.txt
 
 ```
 pip uninstall onnxruntime onnxruntime-gpu
-pip install onnxruntime-gpu==1.16.3
+pip install onnxruntime-gpu==1.18.0
 
 ```
 


### PR DESCRIPTION
The version 1.16.3 cannot be installed anymore but the readme file still lists 1.16.3 if one wishes tot use CUDA. This version (1.18.0) also matches the one in requirements.txt file

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the onnxruntime-gpu version in the README to 1.18.0 to ensure consistency with the requirements.txt file and address the unavailability of version 1.16.3.

Documentation:
- Update the onnxruntime-gpu version in the README from 1.16.3 to 1.18.0 to match the version in requirements.txt.

<!-- Generated by sourcery-ai[bot]: end summary -->