### PR TITLE
Stop live mode when the preview window is closed

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -74,7 +74,7 @@ def parse_args() -> None:
         modules.globals.fp_ui['face_enhancer'] = True
     else:
         modules.globals.fp_ui['face_enhancer'] = False
-    
+
     modules.globals.nsfw = False
 
     # translate deprecated args
@@ -164,7 +164,6 @@ def update_status(message: str, scope: str = 'DLC.CORE') -> None:
     print(f'[{scope}] {message}')
     if not modules.globals.headless:
         ui.update_status(message)
-
 
 def start() -> None:
     for frame_processor in get_frame_processors_modules(modules.globals.frame_processors):

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -61,11 +61,11 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
     target_label = ctk.CTkLabel(root, text=None)
     target_label.place(relx=0.6, rely=0.1, relwidth=0.3, relheight=0.25)
 
-    source_button = ctk.CTkButton(root, text='Select a face', cursor='hand2', command=lambda: select_source_path())
-    source_button.place(relx=0.1, rely=0.4, relwidth=0.3, relheight=0.1)
+    select_face_button = ctk.CTkButton(root, text='Select a face', cursor='hand2', command=lambda: select_source_path())
+    select_face_button.place(relx=0.1, rely=0.4, relwidth=0.3, relheight=0.1)
 
-    target_button = ctk.CTkButton(root, text='Select a target', cursor='hand2', command=lambda: select_target_path())
-    target_button.place(relx=0.6, rely=0.4, relwidth=0.3, relheight=0.1)
+    select_target_button = ctk.CTkButton(root, text='Select a target', cursor='hand2', command=lambda: select_target_path())
+    select_target_button.place(relx=0.6, rely=0.4, relwidth=0.3, relheight=0.1)
 
     keep_fps_value = ctk.BooleanVar(value=modules.globals.keep_fps)
     keep_fps_checkbox = ctk.CTkSwitch(root, text='Keep fps', variable=keep_fps_value, cursor='hand2', command=lambda: setattr(modules.globals, 'keep_fps', not modules.globals.keep_fps))
@@ -253,7 +253,7 @@ def webcam_preview():
     if modules.globals.source_path is None:
         # No image selected
         return
-    
+
     global preview_label, PREVIEW
 
     cap = cv2.VideoCapture(0)  # Use index for the webcam (adjust the index accordingly if necessary)    
@@ -291,6 +291,9 @@ def webcam_preview():
         image = ctk.CTkImage(image, size=image.size)
         preview_label.configure(image=image)
         ROOT.update()
+
+        if PREVIEW.state() == 'withdrawn':
+            break
 
     cap.release()
     PREVIEW.withdraw()  # Close preview window when loop is finished


### PR DESCRIPTION
Otherwise, you have to stop the application to stop using the CPU and break the while-loop

Add a print statement in the while loop to test

`modules/ui.py`
```diff
     while True:
+        print(f"Webcam preview: {PREVIEW.state()}")
         ret, frame = cap.read()
```

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue of continuous CPU usage by breaking the webcam preview loop when the preview window is closed. Improve code readability by renaming UI button variables.

Bug Fixes:
- Stop the webcam preview loop when the preview window is closed to prevent unnecessary CPU usage.

Enhancements:
- Rename UI button variables for selecting a face and target to improve code readability.

<!-- Generated by sourcery-ai[bot]: end summary -->