### PR TITLE
Update README.md to address the issue with the GTK package on MAC OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ We highly recommend to work with a  `venv`  to avoid issues.
 ```
 pip install -r requirements.txt
 ```
+For MAC OS, You have to install or upgrade python-tk pacakage:
+```
+brew install python-tk@3.10
+```
 ##### DONE!!! If you dont have any GPU, You should be able to run roop using `python run.py` command. Keep in mind that while running the program for first time, it will download some models which can take time depending on your network connection.
 
 ### *Proceed if you want to use GPU Acceleration

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We highly recommend to work with a  `venv`  to avoid issues.
 ```
 pip install -r requirements.txt
 ```
-For MAC OS, You have to install or upgrade python-tk pacakage:
+For MAC OS, You have to install or upgrade python-tk package:
 ```
 brew install python-tk@3.10
 ```


### PR DESCRIPTION
On MAC OS, if you encounter the following issues that cannot be resolved with the command `python -m pip install tk-tools`:

> ModuleNotFoundError: No module named '_tkinter'

Or

> DEPRECATION WARNING: The system version of Tk is deprecated and may be removed in a future release. Please don't rely on it. Set TK_SILENCE_DEPRECATION=1 to suppress this warning.

The recommended solution is to use Homebrew to install the required package:
`brew install python-tk@3.10`

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the README.md to provide guidance on resolving issues related to the GTK package on MAC OS by installing or upgrading the python-tk package using Homebrew.

Documentation:
- Update README.md to include instructions for installing or upgrading the python-tk package on MAC OS using Homebrew.

<!-- Generated by sourcery-ai[bot]: end summary -->