### PR TITLE
Allow Drag-and-Drop of Source and Target Files

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -156,10 +156,10 @@ def update_tumbler(var: str, value: bool) -> None:
     modules.globals.fp_ui[var] = value
 
 def drop_source_file(e) -> None:
-    set_source_path( e.data.replace("{","").replace("}", ""))
+    set_source_path( e.data.strip('{}'))
 
 def drop_target_file(e) -> None:
-    set_target_path( e.data.replace("{","").replace("}", ""))
+    set_target_path( e.data.strip('{}'))
 
 def select_source_path() -> None:
     global RECENT_DIRECTORY_SOURCE, img_ft, vid_ft

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ onnx==1.16.0
 insightface==0.7.3
 psutil==5.9.8
 tk==0.1.0
+tkinterdnd2==0.4.2
 customtkinter==5.2.2
 pillow==9.5.0
 torch==2.0.1+cu118; sys_platform != 'darwin'


### PR DESCRIPTION
Commit adds library tkinterdnd2 to enable dragging and dropping of source and target files from the file explorer.

Note that on Visual Studio Code, drag and drop may be blocked if VSCode was installed per-user, instead of for all users.

I am not a python programmer, but have tested this myself on Windows 10, and it works.

It may be you don't want to use the additional tkinter library in which case you can ignore.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Integrate drag-and-drop functionality for source and target files in the UI by using the tkinterdnd2 library. Refactor the UI initialization to support this feature, allowing users to drag files directly from the file explorer into the application.

New Features:
- Enable drag-and-drop functionality for source and target files using the tkinterdnd2 library.

Enhancements:
- Refactor the UI initialization to use a custom CTk class that integrates TkinterDnD for drag-and-drop support.

<!-- Generated by sourcery-ai[bot]: end summary -->