### PR TITLE
change directml to dml in README code example for execution provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ pip install onnxruntime-directml==1.15.1
 2.  Usage in case the provider is available:
 
 ```
-python run.py --execution-provider directml
+python run.py --execution-provider dml
 
 ```
 


### PR DESCRIPTION
Update README to use correct DirectML execution provider argument (dml)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Correct the execution provider name in the README.md usage instructions from 'directml' to 'dml'.

Documentation:
- Update the README.md to correct the execution provider name from 'directml' to 'dml' in the usage instructions.

<!-- Generated by sourcery-ai[bot]: end summary -->