### PR TITLE
Adding a swap faces button to easily swap source/target images

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -66,6 +66,9 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
     select_face_button = ctk.CTkButton(root, text='Select a face', cursor='hand2', command=lambda: select_source_path())
     select_face_button.place(relx=0.1, rely=0.4, relwidth=0.3, relheight=0.1)
 
+    swap_faces_button = ctk.CTkButton(root, text='↔', cursor='hand2', command=lambda: swap_faces_paths())
+    swap_faces_button.place(relx=0.45, rely=0.4, relwidth=0.1, relheight=0.1)
+
     select_target_button = ctk.CTkButton(root, text='Select a target', cursor='hand2', command=lambda: select_target_path())
     select_target_button.place(relx=0.6, rely=0.4, relwidth=0.3, relheight=0.1)
 
@@ -157,6 +160,30 @@ def select_source_path() -> None:
     else:
         modules.globals.source_path = None
         source_label.configure(image=None)
+
+
+def swap_faces_paths() -> None:
+    global RECENT_DIRECTORY_SOURCE, RECENT_DIRECTORY_TARGET
+
+    source_path = modules.globals.source_path
+    target_path = modules.globals.target_path
+
+    if not is_image(source_path) or not is_image(target_path):
+        return
+
+    modules.globals.source_path = target_path
+    modules.globals.target_path = source_path
+
+    RECENT_DIRECTORY_SOURCE = os.path.dirname(modules.globals.source_path)
+    RECENT_DIRECTORY_TARGET = os.path.dirname(modules.globals.target_path)
+
+    PREVIEW.withdraw()
+
+    source_image = render_image_preview(modules.globals.source_path, (200, 200))
+    source_label.configure(image=source_image)
+
+    target_image = render_image_preview(modules.globals.target_path, (200, 200))
+    target_label.configure(image=target_image)
 
 
 def select_target_path() -> None:


### PR DESCRIPTION
Simply added a button between select face and select target buttons to swap source/target images easily (for people that want to quickly do the both versions of the result)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new button in the UI to facilitate swapping the source and target images, enhancing user convenience for generating both versions of a result.

New Features:
- Add a swap faces button to the UI, allowing users to easily swap the source and target images.

<!-- Generated by sourcery-ai[bot]: end summary -->