### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ We highly recommend to work with a  `venv`  to avoid issues.
 ```
 pip install -r requirements.txt
 ```
+or try if above failed
+```
+pip install --use-pep517 -r requirements.txt
+
+```
 For MAC OS, You have to install or upgrade python-tk package:
 ```
 brew install python-tk@3.10


### PR DESCRIPTION
pip install  -r requirements.txt didn't work so I tried this worked pip install --use-pep517 -r requirements.txt

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the README.md to provide an alternative pip installation command using --use-pep517 for cases where the standard command does not work.

Documentation:
- Update README.md to include an alternative pip install command using --use-pep517 in case the standard command fails.

<!-- Generated by sourcery-ai[bot]: end summary -->