### PR TITLE
fix: requirements ResolutionImpossible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://download.pytorch.org/whl/cu118
 
-numpy==1.23.5
+numpy>=1.23.5,<2
 opencv-python==4.8.1.78
 onnx==1.16.0
 insightface==0.7.3


### PR DESCRIPTION
Having Linux with `Python 3.11.2`, I was not able to install the requirements in a **venv**.

```
ERROR: Cannot install -r requirements.txt (line 13), -r requirements.txt (line 17), -r requirements.txt (line 4), -r requirements.txt (line 5), -r requirements.txt (line 6) and numpy==1.23.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested numpy==1.23.5
    opencv-python 4.8.1.78 depends on numpy>=1.21.2; python_version >= "3.10"
    opencv-python 4.8.1.78 depends on numpy>=1.23.5; python_version >= "3.11"
    opencv-python 4.8.1.78 depends on numpy>=1.17.0; python_version >= "3.7"
    opencv-python 4.8.1.78 depends on numpy>=1.17.3; python_version >= "3.8"
    opencv-python 4.8.1.78 depends on numpy>=1.19.3; python_version >= "3.9"
    onnx 1.16.0 depends on numpy>=1.20
    insightface 0.7.3 depends on numpy
    torchvision 0.15.2+cu118 depends on numpy
    onnxruntime-gpu 1.18.0 depends on numpy>=1.24.2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```