### PR TITLE
fix: update model face-swapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Users of this software are expected to use this software responsibly while abidi
 #### 3. Download Models
 
  1. [GFPGANv1.4](https://huggingface.co/hacksider/deep-live-cam/resolve/main/GFPGANv1.4.pth)
- 2. [inswapper_128_fp16.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx)
+ 2. [inswapper_128_fp16.onnx](https://github.com/facefusion/facefusion-assets/releases/download/models/inswapper_128_fp16.onnx)
 
 Then put those 2 files on the "**models**" folder
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Users of this software are expected to use this software responsibly while abidi
 #### 3. Download Models
 
  1. [GFPGANv1.4](https://huggingface.co/hacksider/deep-live-cam/resolve/main/GFPGANv1.4.pth)
- 2. [inswapper_128_fp16.onnx](https://github.com/facefusion/facefusion-assets/releases/download/models/inswapper_128_fp16.onnx)
+ 2. [inswapper_128_fp16.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx) *(Note: Use this [replacement version](https://github.com/facefusion/facefusion-assets/releases/download/models/inswapper_128_fp16.onnx) if an issue occurs on your computer)*
 
 Then put those 2 files on the "**models**" folder
 


### PR DESCRIPTION
The model `inswapper_128_fp16.onnx` provided from HuggingFace seems to be buggy, causing to show black squares in the face, instead of the face being swapped.

By using the model from GitHub, it works.

Fixes #189 #162 and maybe other related issues.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the model source for `inswapper_128_fp16.onnx` to fix face swap issues and update the README with the new model download link.

Bug Fixes:
- Fix the issue of black squares appearing in face swaps by updating the model source for `inswapper_128_fp16.onnx` from HuggingFace to GitHub.

Documentation:
- Update the README to reflect the new download link for the `inswapper_128_fp16.onnx` model from GitHub.

<!-- Generated by sourcery-ai[bot]: end summary -->