### PR TITLE
Updates to multiple face support (webcam scenario)

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -101,19 +101,30 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
                         for target_face in frame['faces']:
                             temp_frame = swap_face(source_face, target_face, temp_frame)
     else:
-        many_faces = get_many_faces(temp_frame)
+        detected_faces = get_many_faces(temp_frame)
         if modules.globals.many_faces:
-            source_face = default_source_face()
-            if many_faces:
-                for target_face in many_faces:
+            if detected_faces:
+                source_face = default_source_face()
+                for target_face in detected_faces:
                     temp_frame = swap_face(source_face, target_face, temp_frame)
 
         elif not modules.globals.many_faces:
-            if many_faces:
-                for target_face in many_faces:
-                    closest_centroid_index, _ = find_closest_centroid(modules.globals.simple_map['target_embeddings'], target_face.normed_embedding)
+            if detected_faces:
+                if len(detected_faces) <= len(modules.globals.simple_map['target_embeddings']):
+                    for detected_face in detected_faces:
+                        closest_centroid_index, _ = find_closest_centroid(modules.globals.simple_map['target_embeddings'], detected_face.normed_embedding)
 
-                    temp_frame = swap_face(modules.globals.simple_map['source_faces'][closest_centroid_index], target_face, temp_frame)
+                        temp_frame = swap_face(modules.globals.simple_map['source_faces'][closest_centroid_index], detected_face, temp_frame)
+                else:
+                    detected_faces_centroids = []
+                    for face in detected_faces:
+                            detected_faces_centroids.append(face.normed_embedding)
+                    i = 0
+                    for target_embedding in modules.globals.simple_map['target_embeddings']:
+                        closest_centroid_index, _ = find_closest_centroid(detected_faces_centroids, target_embedding)
+
+                        temp_frame = swap_face(modules.globals.simple_map['source_faces'][i], detected_faces[closest_centroid_index], temp_frame)
+                        i += 1
     return temp_frame
 
 


### PR DESCRIPTION
Current behavior:
When the number of faces detected in the webcam scene are greater than the number of face maps selected, all faces are replaced to their closest match

Behavior after update:
When the number of faces detected in the webcam scene are greater than the number of face maps selected,
only detected faces which match provided face maps will be replaced, rest of the detected faces will remain as they are.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the face swapping logic to ensure that only detected faces matching the provided face maps are replaced, leaving unmatched faces unchanged when the number of detected faces exceeds the number of face maps.

Enhancements:
- Improve face swapping logic to handle scenarios where the number of detected faces exceeds the number of available face maps by only replacing faces that match provided face maps.

<!-- Generated by sourcery-ai[bot]: end summary -->