### PR TITLE
Downgrade onnxruntime version to 1.16.0 to fix requirements installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,8 @@ torch==2.0.1+cu118; sys_platform != 'darwin'
 torch==2.0.1; sys_platform == 'darwin'
 torchvision==0.15.2+cu118; sys_platform != 'darwin'
 torchvision==0.15.2; sys_platform == 'darwin'
-onnxruntime==1.18.0; sys_platform == 'darwin' and platform_machine != 'arm64'
 onnxruntime-silicon==1.16.3; sys_platform == 'darwin' and platform_machine == 'arm64'
-onnxruntime-gpu==1.18.0; sys_platform != 'darwin'
-tensorflow==2.13.0rc1; sys_platform == 'darwin'
+onnxruntime-gpu==1.16.0; sys_platform != 'darwin'
 tensorflow==2.12.1; sys_platform != 'darwin'
 opennsfw2==0.10.2
 protobuf==4.23.2


### PR DESCRIPTION
Fix for https://github.com/hacksider/Deep-Live-Cam/issues/603