### PR TITLE
Adding headless parameter to arguments to run from the cli, reenabling macOS compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ options:
   --execution-provider {cpu} [{cpu} ...]                   available execution provider (choices: cpu, ...)
   --execution-threads EXECUTION_THREADS                    number of execution threads
   --headless                                               run in headless mode
+  --enhancer-upscale-factor                                Sets the upscale factor for the enhancer. Only applies if `face_enhancer` is set as a frame-processor
   -v, --version                                            show program's version number and exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ options:
   --max-memory MAX_MEMORY                                  maximum amount of RAM in GB
   --execution-provider {cpu} [{cpu} ...]                   available execution provider (choices: cpu, ...)
   --execution-threads EXECUTION_THREADS                    number of execution threads
+  --headless                                               run in headless mode
   -v, --version                                            show program's version number and exit
 ```
 

--- a/modules/core.py
+++ b/modules/core.py
@@ -71,6 +71,9 @@ def parse_args() -> None:
     program.add_argument('--execution-threads', help='Number of execution threads', dest='execution_threads', type=int,
                          default=suggest_execution_threads())
     program.add_argument('--headless', help='Run in headless mode', dest='headless', default=False, action='store_true')
+    program.add_argument('--enhancer_upscale_factor',
+                         help='Sets the upscale factor for the enhancer. Only applies if `face_enhancer` is set as a frame_processor',
+                         dest='enhancer_upscale_factor', type=int, default=1)
     program.add_argument('-v', '--version', action='version',
                          version=f'{modules.metadata.name} {modules.metadata.version}')
 
@@ -100,7 +103,7 @@ def parse_args() -> None:
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
     modules.globals.headless = args.headless
-
+    modules.globals.enhancer_upscale_factor = args.enhancer_upscale_factor
     # Handle face enhancer tumbler
     modules.globals.fp_ui['face_enhancer'] = 'face_enhancer' in args.frame_processor
 

--- a/modules/core.py
+++ b/modules/core.py
@@ -70,6 +70,7 @@ def parse_args() -> None:
                          choices=suggest_execution_providers(), nargs='+')
     program.add_argument('--execution-threads', help='Number of execution threads', dest='execution_threads', type=int,
                          default=suggest_execution_threads())
+    program.add_argument('--headless', help='Run in headless mode', dest='headless', default=False, action='store_true')
     program.add_argument('-v', '--version', action='version',
                          version=f'{modules.metadata.name} {modules.metadata.version}')
 
@@ -98,6 +99,7 @@ def parse_args() -> None:
     modules.globals.max_memory = args.max_memory
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
+    modules.globals.headless = args.headless
 
     # Handle face enhancer tumbler
     modules.globals.fp_ui['face_enhancer'] = 'face_enhancer' in args.frame_processor

--- a/modules/core.py
+++ b/modules/core.py
@@ -71,8 +71,8 @@ def parse_args() -> None:
     program.add_argument('--execution-threads', help='Number of execution threads', dest='execution_threads', type=int,
                          default=suggest_execution_threads())
     program.add_argument('--headless', help='Run in headless mode', dest='headless', default=False, action='store_true')
-    program.add_argument('--enhancer_upscale_factor',
-                         help='Sets the upscale factor for the enhancer. Only applies if `face_enhancer` is set as a frame_processor',
+    program.add_argument('--enhancer-upscale-factor',
+                         help='Sets the upscale factor for the enhancer. Only applies if `face_enhancer` is set as a frame-processor',
                          dest='enhancer_upscale_factor', type=int, default=1)
     program.add_argument('-v', '--version', action='version',
                          version=f'{modules.metadata.name} {modules.metadata.version}')

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -30,3 +30,4 @@ fp_ui: Dict[str, bool] = {}
 nsfw = None
 camera_input_combobox = None
 webcam_preview_running = False
+enhancer_upscale_factor = 1

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -33,7 +33,10 @@ def get_face_enhancer() -> Any:
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
             model_path = resolve_relative_path('../models/GFPGANv1.4.pth')
-            FACE_ENHANCER = gfpgan.GFPGANer(model_path=model_path, upscale=1)  # type: ignore[attr-defined]
+            FACE_ENHANCER = gfpgan.GFPGANer(
+                model_path=model_path,
+                upscale=modules.globals.enhancer_upscale_factor
+            )  # type: ignore[attr-defined]
     return FACE_ENHANCER
 
 def enhance_face(temp_frame: Frame) -> Frame:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -6,14 +6,15 @@ from typing import Callable, Tuple, List, Any
 from types import ModuleType
 import cv2
 from PIL import Image, ImageOps
-from pygrabber.dshow_graph import FilterGraph
 import pyvirtualcam
 
 # Import OS-specific modules only when necessary
 if platform.system() == 'Darwin':  # macOS
-    import objc
-    from Foundation import NSObject
     import AVFoundation
+
+if os.name == 'nt':  # Windows
+    from pygrabber.dshow_graph import FilterGraph
+
 
 import modules.globals
 import modules.metadata

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -13,7 +13,7 @@ if platform.system() == 'Darwin':  # macOS
     import AVFoundation
 
 # Import Windows specific modules only when on windows platform
-if os.name == 'nt':  # Windows
+if platform.system() == 'Windows' or platform.system() == 'Linux':  # Windows or Linux
     from pygrabber.dshow_graph import FilterGraph
 
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -12,6 +12,7 @@ import pyvirtualcam
 if platform.system() == 'Darwin':  # macOS
     import AVFoundation
 
+# Import Windows specific modules only when on windows platform
 if os.name == 'nt':  # Windows
     from pygrabber.dshow_graph import FilterGraph
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ gfpgan==1.3.8
 pyobjc==9.1; sys_platform == 'darwin'
 pygrabber==0.2
 pyvirtualcam==0.12.0
+pyobjc-framework-AVFoundation==10.3.1; sys_platform == 'darwin'


### PR DESCRIPTION
Added headless parameter to arguments to run from the cli.

These changes were made after sourcery created the summary:

- removed unused import statements in ui.py
- added macOS specific required library to requirements.txt
- conditional import of pygrabber, which is unavailable for macOS
- Allows to set the upscale factor for  gfpgan face_enhancer


<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a headless parameter to the command-line arguments to enable running the application in headless mode.

New Features:
- Introduce a headless mode option to the command-line interface, allowing users to run the program without a graphical user interface.

<!-- Generated by sourcery-ai[bot]: end summary -->