### PR TITLE
Fix ui.py

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -95,7 +95,7 @@ def save_switch_states():
         "live_resizable": modules.globals.live_resizable,
         "fp_ui": modules.globals.fp_ui,
         "show_fps": modules.globals.show_fps,
-        "mouth_mask": modules.globals.mouth_mask
+        "mouth_mask": modules.globals.mouth_mask,
         "show_mouth_mask_box": modules.globals.show_mouth_mask_box
     }
     with open("switch_states.json", "w") as f:


### PR DESCRIPTION
Add command to "mouth_mask": modules.globals.mouth_mask which fixes the error "SyntaxError: invalid syntax. Perhaps you forgot a comma?"

## Summary by Sourcery

Bug Fixes:
- Fix syntax error by adding a missing comma in the dictionary definition in ui.py.