### PR TITLE
fix for GfpGAN and inswapper model path retrieval bug

### DIFF
--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -11,7 +11,6 @@ from modules.face_analyser import get_one_face
 from modules.typing import Frame, Face
 from modules.utilities import (
     conditional_download,
-    resolve_relative_path,
     is_image,
     is_video,
 )
@@ -21,9 +20,11 @@ THREAD_SEMAPHORE = threading.Semaphore()
 THREAD_LOCK = threading.Lock()
 NAME = "DLC.FACE-ENHANCER"
 
+abs_dir = os.path.dirname(os.path.abspath(__file__))
+models_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(abs_dir))), 'models')
 
 def pre_check() -> bool:
-    download_directory_path = resolve_relative_path("..\models")
+    download_directory_path = models_dir
     conditional_download(
         download_directory_path,
         [
@@ -47,11 +48,7 @@ def get_face_enhancer() -> Any:
 
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
-            if os.name == "nt":
-                model_path = resolve_relative_path("..\models\GFPGANv1.4.pth")
-                # todo: set models path https://github.com/TencentARC/GFPGAN/issues/399
-            else:
-                model_path = resolve_relative_path("../models/GFPGANv1.4.pth")
+            model_path = os.path.join(models_dir, 'GFPGANv1.4.pth')
             FACE_ENHANCER = gfpgan.GFPGANer(model_path=model_path, upscale=1)  # type: ignore[attr-defined]
     return FACE_ENHANCER
 

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -10,19 +10,21 @@ from modules.face_analyser import get_one_face, get_many_faces, default_source_f
 from modules.typing import Face, Frame
 from modules.utilities import (
     conditional_download,
-    resolve_relative_path,
     is_image,
     is_video,
 )
 from modules.cluster_analysis import find_closest_centroid
+import os
 
 FACE_SWAPPER = None
 THREAD_LOCK = threading.Lock()
 NAME = "DLC.FACE-SWAPPER"
 
+abs_dir = os.path.dirname(os.path.abspath(__file__))
+models_dir = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(abs_dir))), 'models')
 
 def pre_check() -> bool:
-    download_directory_path = resolve_relative_path("../models")
+    download_directory_path = abs_dir
     conditional_download(
         download_directory_path,
         [
@@ -54,7 +56,7 @@ def get_face_swapper() -> Any:
 
     with THREAD_LOCK:
         if FACE_SWAPPER is None:
-            model_path = resolve_relative_path("../models/inswapper_128_fp16.onnx")
+            model_path = os.path.join(models_dir, 'inswapper_128_fp16.onnx')
             FACE_SWAPPER = insightface.model_zoo.get_model(
                 model_path, providers=modules.globals.execution_providers
             )


### PR DESCRIPTION
Hi. not too long ago i was getting the error that is described in this issue: https://github.com/hacksider/Deep-Live-Cam/issues/770
I added a fix for this bug (it was a misconstructed path)

## Summary by Sourcery

Bug Fixes:
- Fix incorrect model path retrieval for GfpGAN and inswapper models by constructing absolute paths.