### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ torch==2.0.1; sys_platform == 'darwin'
 torchvision==0.15.2+cu118; sys_platform != 'darwin'
 torchvision==0.15.2; sys_platform == 'darwin'
 onnxruntime-silicon==1.16.3; sys_platform == 'darwin' and platform_machine == 'arm64'
+onnxruntime==1.16.3; sys_platform == 'darwin' and platform_machine == 'x86_64'
 onnxruntime-gpu==1.16.3; sys_platform != 'darwin'
 tensorflow==2.12.1; sys_platform != 'darwin'
 opennsfw2==0.10.2


### PR DESCRIPTION
The PR fixes the error `ModuleNotFoundError: No module named 'onnxruntime'` when running it on intel based mac.

## Summary by Sourcery

Bug Fixes:
- Fixed `ModuleNotFoundError: No module named 'onnxruntime'` on intel-based macs by adding onnxruntime to the requirements for x86_64 architecture.