### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,9 +11,9 @@ tk==0.1.0
 customtkinter==5.2.2
 pillow==11.1.0
 torch==2.5.1+cu118; sys_platform != 'darwin'
-torch==2.5.1+cu118; sys_platform == 'darwin'
+torch==2.5.1; sys_platform == 'darwin'
 torchvision==0.20.1; sys_platform != 'darwin'
-torchvision==0.20.1+cu118; sys_platform == 'darwin'
+torchvision==0.20.1; sys_platform == 'darwin'
 onnxruntime-silicon==1.16.3; sys_platform == 'darwin' and platform_machine == 'arm64'
 onnxruntime-gpu==1.16.3; sys_platform != 'darwin'
 tensorflow; sys_platform != 'darwin'


### PR DESCRIPTION
Made changes for apple silicon. 

Or getting
ERROR: Could not find a version that satisfies the requirement torch==2.5.1+cu118 (from versions: 1.11.0, 1.12.0, 1.12.1, 1.13.0, 1.13.1, 2.0.0, 2.0.1, 2.1.0, 2.1.1, 2.1.2, 2.2.0, 2.2.1, 2.2.2, 2.3.0, 2.3.1, 2.4.0, 2.4.1, 2.5.0, 2.5.1, 2.6.0) ERROR: No matching distribution found for torch==2.5.1+cu118

## Summary by Sourcery

Build:
- Install `torch` and `torchvision` without CUDA extensions on Apple Silicon systems.