### PR TITLE
How to fix insightface warnings on Apple Silicon info

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-**If error `_Warning: Package 'insightface.data.images/insightface.data.objects/insightface.thirdparty.face3d.mesh.cython' is absent from the packages configuration` occur you need to use llvm as compiler**
+**If error `_Warning: Package 'insightface.data.images/insightface.data.objects/insightface.thirdparty.face3d.mesh.cython' is absent from the packages configuration` occurs you need to use llvm as compiler**
 
 ```bash
 # Install llvm libomp

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-** In case something goes wrong and you need to reinstall the virtual environment **
+**In case something goes wrong and you need to reinstall the virtual environment**
 
 ```bash
 # Deactivate the virtual environment
@@ -177,7 +177,21 @@ rm -rf venv
 python -m venv venv
 source venv/bin/activate
 
-# install the dependencies again
+# Install the dependencies again
+pip install -r requirements.txt
+```
+
+**If error `_Warning: Package 'insightface.data.images/insightface.data.objects/insightface.thirdparty.face3d.mesh.cython' is absent from the packages configuration` occur you need to use llvm as compiler**
+
+```bash
+# Install llvm libomp
+brew install llvm libomp
+
+# Export compiler variables
+export CC=$(brew --prefix llvm)/bin/clang
+export CXX=$(brew --prefix llvm)/bin/clang++
+
+# Install the dependencies again
 pip install -r requirements.txt
 ```
 


### PR DESCRIPTION
How to fix _Warning: Package 'insightface.data.images/insightface.data.objects/insightface.thirdparty.face3d.mesh.cython' is absent from the packages configuration info added

## Summary by Sourcery

Update README with instructions for resolving insightface package warnings on Apple Silicon

Enhancements:
- Improve formatting of existing virtual environment reinstallation instructions

Documentation:
- Add troubleshooting steps for resolving insightface package configuration warnings on macOS