### PR TITLE
Fix model download path and URL

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -28,11 +28,17 @@ models_dir = os.path.join(
 
 
 def pre_check() -> bool:
-    download_directory_path = abs_dir
+    # Use models_dir instead of abs_dir to save to the correct location
+    download_directory_path = models_dir
+    
+    # Make sure the models directory exists
+    os.makedirs(download_directory_path, exist_ok=True)
+    
+    # Use the direct download URL from Hugging Face
     conditional_download(
         download_directory_path,
         [
-            "https://huggingface.co/hacksider/deep-live-cam/blob/main/inswapper_128_fp16.onnx"
+            "https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx"
         ],
     )
     return True


### PR DESCRIPTION
This PR improves the model downloading process by:
- Using models_dir instead of abs_dir for the download path
- Creating the models directory if it doesn't exist
- Fixing the Hugging Face download URL by using /resolve/ instead of /blob/

These changes make the model downloading process more robust and reliable.