### PR TITLE
Update __init__.py

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,3 +1,4 @@
+import os 
 import cv2
 import numpy as np
 
@@ -11,8 +12,11 @@ cv2.imread = imread_unicode
 # Define a function to support unicode characters in file paths when saving
 def imwrite_unicode(path, img, params=None):
     # Encode the image
-    ext = path.split(".")[-1]  # Get file extension
-    result, encoded_img = cv2.imencode(f".{ext}", img, params if params else [])
+    root, ext = os.path.splitext(path)
+    # If no extension is found, you can choose a default extension (e.g., ".png")
+    if not ext:
+        ext = ".png"
+    result, encoded_img = cv2.imencode(ext, img, params if params else [])
 
     if result:
         encoded_img.tofile(path)  # Save image using numpy's `tofile()`

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -2,26 +2,17 @@ import os
 import cv2
 import numpy as np
 
-# Define a new function that supports unicode characters in file paths
+# Utility function to support unicode characters in file paths for reading
 def imread_unicode(path, flags=cv2.IMREAD_COLOR):
     return cv2.imdecode(np.fromfile(path, dtype=np.uint8), flags)
 
-# Override the original `cv2.imread`
-cv2.imread = imread_unicode
-
-# Define a function to support unicode characters in file paths when saving
+# Utility function to support unicode characters in file paths for writing
 def imwrite_unicode(path, img, params=None):
-    # Encode the image
     root, ext = os.path.splitext(path)
-    # If no extension is found, you can choose a default extension (e.g., ".png")
     if not ext:
         ext = ".png"
     result, encoded_img = cv2.imencode(ext, img, params if params else [])
-
     if result:
-        encoded_img.tofile(path)  # Save image using numpy's `tofile()`
+        encoded_img.tofile(path)
         return True
     return False
-
-# Override `cv2.imwrite`
-cv2.imwrite = imwrite_unicode

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,23 @@
+import cv2
+import numpy as np
+
+# Define a new function that supports unicode characters in file paths
+def imread_unicode(path, flags=cv2.IMREAD_COLOR):
+    return cv2.imdecode(np.fromfile(path, dtype=np.uint8), flags)
+
+# Override the original `cv2.imread`
+cv2.imread = imread_unicode
+
+# Define a function to support unicode characters in file paths when saving
+def imwrite_unicode(path, img, params=None):
+    # Encode the image
+    ext = path.split(".")[-1]  # Get file extension
+    result, encoded_img = cv2.imencode(f".{ext}", img, params if params else [])
+
+    if result:
+        encoded_img.tofile(path)  # Save image using numpy's `tofile()`
+        return True
+    return False
+
+# Override `cv2.imwrite`
+cv2.imwrite = imwrite_unicode

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -12,7 +12,7 @@ def imwrite_unicode(path, img, params=None):
     if not ext:
         ext = ".png"
     result, encoded_img = cv2.imencode(ext, img, params if params else [])
-    if result:
+    result, encoded_img = cv2.imencode(f".{ext}", img, params if params is not None else [])
         encoded_img.tofile(path)
         return True
     return False


### PR DESCRIPTION
## Issue: Global Override of `cv2.imread` and `cv2.imwrite` for Unicode Path Support

### Description
The current implementation in `modules/__init__.py` globally overrides `cv2.imread` and `cv2.imwrite` to support Unicode file paths by using `np.fromfile` and `np.tofile`. While this enables reading and writing images with Unicode paths, it replaces the original OpenCV functions for the entire project, which may cause unexpected behavior in other modules or third-party libraries that rely on the standard `cv2` API.

### Expected Behavior
- The codebase should support reading and writing images with Unicode file paths.
- The solution should not globally override standard library functions unless absolutely necessary.
- If overriding is required, it should be done in a controlled and well-documented manner.

### Actual Behavior
- `cv2.imread` and `cv2.imwrite` are overridden globally for all imports, which may break compatibility with other code or libraries.

### Suggested Solution
- Refactor the Unicode-supporting functions to be utility functions (e.g., `imread_unicode`, `imwrite_unicode`) and use them explicitly where needed, rather than overriding the global `cv2` functions.
- Alternatively, conditionally override only if Unicode support is detected as missing, and document the change clearly.

## Summary by Sourcery

Modify image reading and writing functions to support Unicode file paths by creating utility functions and globally overriding OpenCV's imread and imwrite methods

New Features:
- Add Unicode-compatible image reading function `imread_unicode`
- Add Unicode-compatible image writing function `imwrite_unicode`

Enhancements:
- Provide alternative implementation for handling file paths with non-ASCII characters
- Enable reading and writing images with Unicode file paths