### PR TITLE
Correct URL for Star-History

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Looking for a CLI mode? Using the -s/--source argument will make the run program
 
 ## Stars to the Moon 🚀
 
-<a href="https://star-history.com/#hacksider/deep-live-cam&Date">
+<a href="https://www.star-history.com/#hacksider/deep-live-cam&Date">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hacksider/deep-live-cam&type=Date&theme=dark" />
    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hacksider/deep-live-cam&type=Date" />


### PR DESCRIPTION
Hi 👋 ,

This fixes #1215

Regards,
Konrad

## Summary by Sourcery

Update Star-History URL in README to use the correct domain

Bug Fixes:
- Fixed incorrect URL for Star-History badge in project README

Documentation:
- Corrected the Star-History URL to use 'www.star-history.com' instead of 'star-history.com'