### PR TITLE
Update __init__.py

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -11,8 +11,8 @@ def imwrite_unicode(path, img, params=None):
     root, ext = os.path.splitext(path)
     if not ext:
         ext = ".png"
-    result, encoded_img = cv2.imencode(ext, img, params if params else [])
-    result, encoded_img = cv2.imencode(f".{ext}", img, params if params is not None else [])
+        result, encoded_img = cv2.imencode(ext, img, params if params else [])
+        result, encoded_img = cv2.imencode(f".{ext}", img, params if params is not None else [])
         encoded_img.tofile(path)
         return True
     return False


### PR DESCRIPTION
Fix for windows 11 error:

(venv) C:\...\Deep-Live-Cam>python run.py
Traceback (most recent call last):
  File "C:\...\Deep-Live-Cam\run.py", line 3, in <module>
    from modules import core
  File "C:\...\Deep-Live-Cam\modules\__init__.py", line 16
    encoded_img.tofile(path)
IndentationError: unexpected indent

## Summary by Sourcery

Bug Fixes:
- Adjust indentation of imencode calls in modules/__init__.py to fix UnexpectedIndentError on Windows