### PR TITLE
docs: add cuDNN installation guidance for CUDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,10 @@ pip install -r requirements.txt
 **CUDA Execution Provider (Nvidia)**
 
 1. Install [CUDA Toolkit 11.8.0](https://developer.nvidia.com/cuda-11-8-0-download-archive)
-2. Install dependencies:
+2. Install [cuDNN v8.9.7 for CUDA 11.x](https://developer.nvidia.com/rdp/cudnn-archive) (required for onnxruntime-gpu):
+   - Download cuDNN v8.9.7 for CUDA 11.x
+   - Make sure the cuDNN bin directory is in your system PATH
+3. Install dependencies:
 
 ```bash
 pip uninstall onnxruntime onnxruntime-gpu


### PR DESCRIPTION
## Summary

This pull request improves the documentation by adding instructions about cuDNN requirements when using ONNX Runtime with the CUDA Execution Provider.

## Details

- Notes that ONNX Runtime with CUDA requires cuDNN version 8.2–8.9.
- Recommends downloading cuDNN v8.9 from the [NVIDIA cuDNN archive](https://developer.nvidia.com/rdp/cudnn-archive).
- Reminds users to add the `bin` directory from cuDNN to their system's `PATH` environment variable to ensure required DLLs are found at runtime.

## Background

During setup, a runtime error occurred indicating that cuDNN was not found by ONNX Runtime, even though CUDA was properly installed. Installing cuDNN v8.9 and ensuring the correct environment variable configuration resolved the issue.

## Summary by Sourcery

Add cuDNN installation and PATH configuration guidance to the CUDA Execution Provider section in README

Documentation:
- Document cuDNN v8.2–8.9 requirement for the CUDA Execution Provider
- Guide downloading cuDNN v8.9.7 for CUDA 11.x and adding its bin directory to PATH