### PR TITLE
Add Golem.de (German IT news magazine) article

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Looking for a CLI mode? Using the -s/--source argument will make the run program
  - [*"That's Crazy, Oh God. That's Fucking Freaky Dude... That's So Wild Dude"*](https://www.youtube.com/watch?time_continue=1074&v=py4Tc-Y8BcY) - SomeOrdinaryGamers
  - [*"Alright look look look, now look chat, we can do any face we want to look like chat"*](https://www.youtube.com/live/mFsCe7AIxq8?feature=shared&t=2686) - IShowSpeed
  - [*"They do a pretty good job matching poses, expression and even the lighting"*](https://www.youtube.com/watch?v=wnCghLjqv3s&t=551s) - TechLinked (LTT)
+ - [*"Als Sean Connery an der Redaktionskonferenz teilnahm"*](https://www.golem.de/news/deepfakes-als-sean-connery-an-der-redaktionskonferenz-teilnahm-2408-188172.html) - Golem.de (German)
 
 
 ## Credits


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Add a bullet linking to the "Als Sean Connery an der Redaktionskonferenz teilnahm" article on Golem.de