### PR TITLE
Update metadata.py

### DIFF
--- a/modules/metadata.py
+++ b/modules/metadata.py
@@ -1,3 +1,3 @@
 name = 'Deep-Live-Cam'
-version = '1.8.1'
+version = '2.2'
 edition = 'GitHub Edition'


### PR DESCRIPTION
allineate to download package

## Summary by Sourcery

Enhancements:
- Bump the package version in metadata.py from 1.8.1 to 2.2