### PR TITLE
Update README with Windows dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,11 @@ This is more likely to work on your computer but will be slower as it utilizes t
 -   git
 -   [ffmpeg](https://www.youtube.com/watch?v=OlNWCpFdVMA) - ```iex (irm ffmpeg.tc.ht)```
 -   [Visual Studio 2022 Runtimes (Windows)](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
-
+    - `Windows Universal C Runtime`
+    - `MSVC v143 - VS 2022 C++ x64/x86 build tools`
+    - `Windows 11 SDK`
+    - `Windows Universal CRT SDK`
+  
 **2. Clone the Repository**
 
 ```bash


### PR DESCRIPTION
Added additional Windows dependencies to the README.

List of packages I had to install for the `pip install -r requirements.txt` to work.

## Summary by Sourcery

Update README with additional Windows dependencies required for successful pip installation.

Documentation:
- Document Windows Universal C Runtime as a dependency
- Document MSVC v143 - VS 2022 C++ x64/x86 build tools as a dependency
- Document Windows 11 SDK as a dependency
- Document Windows Universal CRT SDK as a dependency