### PR TITLE
fix: fix typos which caused "No faces found in target" issue

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -26,7 +26,7 @@ keep_fps: bool = True
 keep_audio: bool = True
 keep_frames: bool = False
 many_faces: bool = False         # Process all detected faces with default source
-map_faces: bool = False          # Use souce_target_map or simple_map for specific swaps
+map_faces: bool = False          # Use source_target_map or simple_map for specific swaps
 color_correction: bool = False   # Enable color correction (implementation specific)
 nsfw_filter: bool = False
 

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -341,7 +341,7 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
     source_target_pairs = []
 
     # Ensure maps exist before accessing them
-    souce_target_map = getattr(modules.globals, "souce_target_map", None)
+    source_target_map = getattr(modules.globals, "source_target_map", None)
     simple_map = getattr(modules.globals, "simple_map", None)
 
     # Check if target is a file path (image or video) or live stream
@@ -349,11 +349,11 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
 
     if is_file_target:
         # Processing specific image or video file with pre-analyzed maps
-        if souce_target_map:
+        if source_target_map:
             if modules.globals.many_faces:
                 source_face = default_source_face() # Use default source for all targets
                 if source_face:
-                    for map_data in souce_target_map:
+                    for map_data in source_target_map:
                         if is_image(modules.globals.target_path):
                             target_info = map_data.get("target", {})
                             if target_info: # Check if target info exists
@@ -371,7 +371,7 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
                                          for target_face in faces_in_frame:
                                              source_target_pairs.append((source_face, target_face))
             else: # Single face or specific mapping
-                 for map_data in souce_target_map:
+                 for map_data in source_target_map:
                     source_info = map_data.get("source", {})
                     if not source_info: continue # Skip if no source info
                     source_face = source_info.get("face")

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -465,7 +465,7 @@ def analyze_target(start: Callable[[], None], root: ctk.CTk):
         return
 
     if modules.globals.map_faces:
-        modules.globals.souce_target_map = []
+        modules.globals.source_target_map = []
 
         if is_image(modules.globals.target_path):
             update_status("Getting unique faces")
@@ -474,8 +474,8 @@ def analyze_target(start: Callable[[], None], root: ctk.CTk):
             update_status("Getting unique faces")
             get_unique_faces_from_target_video()
 
-        if len(modules.globals.souce_target_map) > 0:
-            create_source_target_popup(start, root, modules.globals.souce_target_map)
+        if len(modules.globals.source_target_map) > 0:
+            create_source_target_popup(start, root, modules.globals.source_target_map)
         else:
             update_status("No faces found in target")
     else:
@@ -855,9 +855,9 @@ def webcam_preview(root: ctk.CTk, camera_index: int):
             return
         create_webcam_preview(camera_index)
     else:
-        modules.globals.souce_target_map = []
+        modules.globals.source_target_map = []
         create_source_target_popup_for_webcam(
-            root, modules.globals.souce_target_map, camera_index
+            root, modules.globals.source_target_map, camera_index
         )
 
 


### PR DESCRIPTION
Issue:
- The typo `souce_target_map` caused the "No faces found in target" error on the UI when clicking the "Start" button.

Fix:
- Renamed all instances of `souce_target_map` to `source_target_map`.

## Summary by Sourcery

Bug Fixes:
- Rename all instances of `souce_target_map` to `source_target_map` across UI, processor, and globals modules