### PR TITLE
ui: fix crash of live cam on arch-linux

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -29,6 +29,7 @@ from modules.video_capture import VideoCapturer
 from modules.gettext import LanguageManager
 from modules import globals
 import platform
+from numbers import Integral
 
 if platform.system() == "Windows":
     from pygrabber.dshow_graph import FilterGraph
@@ -766,7 +767,7 @@ def check_and_ignore_nsfw(target, destroy: Callable = None) -> bool:
 def fit_image_to_size(image, width: int, height: int):
     if width is None and height is None:
         return image
-    if not isinstance(width, int) or not isinstance(height, int) or width <= 0 or height <= 0:
+    if not isinstance(width, Integral) or not isinstance(height, Integral) or width <= 0 or height <= 0:
         return image
     h, w, _ = image.shape
     if h == 0 or w == 0:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -766,7 +766,11 @@ def check_and_ignore_nsfw(target, destroy: Callable = None) -> bool:
 def fit_image_to_size(image, width: int, height: int):
     if width is None and height is None:
         return image
+    if not isinstance(width, int) or not isinstance(height, int) or width <= 0 or height <= 0:
+        return image
     h, w, _ = image.shape
+    if h == 0 or w == 0:
+        return image
     ratio_h = 0.0
     ratio_w = 0.0
     if width > height:
@@ -775,6 +779,8 @@ def fit_image_to_size(image, width: int, height: int):
         ratio_w = width / w
     ratio = max(ratio_w, ratio_h)
     new_size = (int(ratio * w), int(ratio * h))
+    if new_size[0] <= 0 or new_size[1] <= 0:
+        return image
     return cv2.resize(image, dsize=new_size)
 
 


### PR DESCRIPTION
Ensure the dimensions are valid before attempting the resize operation

## Summary by Sourcery

Bug Fixes:
- Avoid crashes when fitting images by skipping resize if width or height are non-positive or non-integer, or if the image has zero dimensions.