### PR TITLE
Fix NameError: face_outline_points undefined in create_face_mask

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -1090,7 +1090,7 @@ def create_face_mask(face: Face, frame: Frame) -> np.ndarray:
         # Calculate convex hull of these points
         # Use try-except as convexHull can fail on degenerate input
         try:
-             hull = cv2.convexHull(full_face_poly.astype(np.float32)) # Use float for accuracy
+             hull = cv2.convexHull(face_outline_points.astype(np.float32)) # Use float for accuracy
              if hull is None or len(hull) < 3:
                  # print("Warning: Convex hull calculation failed or returned too few points.")
                  # Fallback: use bounding box of landmarks? Or just return empty mask?


### PR DESCRIPTION
Replaces the incorrect variable reference 'full_face_poly' with the correct local variable 'face_outline_points' in the convexHull calculation.

## Summary by Sourcery

Bug Fixes:
- Resolve NameError and incorrect variable usage in create_face_mask by using the local face outline points for convex hull calculation.