### PR TITLE
fix(threading): protect source_target_map with lock

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -68,7 +68,8 @@ def simplify_maps() -> Any:
             centroids.append(map['target']['face'].normed_embedding)
             faces.append(map['source']['face'])
 
-    modules.globals.simple_map = {'source_faces': faces, 'target_embeddings': centroids}
+    with modules.globals.MAP_LOCK:
+        modules.globals.simple_map = {'source_faces': faces, 'target_embeddings': centroids}
     return None
 
 def add_blank_map() -> Any:
@@ -77,28 +78,31 @@ def add_blank_map() -> Any:
         if len(modules.globals.source_target_map) > 0:
             max_id = max(modules.globals.source_target_map, key=lambda x: x['id'])['id']
 
-        modules.globals.source_target_map.append({
-                'id' : max_id + 1
-                })
+        with modules.globals.MAP_LOCK:
+            modules.globals.source_target_map.append({
+                    'id' : max_id + 1
+                    })
     except ValueError:
         return None
     
 def get_unique_faces_from_target_image() -> Any:
     try:
-        modules.globals.source_target_map = []
+        with modules.globals.MAP_LOCK:
+            modules.globals.source_target_map = []
         target_frame = cv2.imread(modules.globals.target_path)
         many_faces = get_many_faces(target_frame)
         i = 0
 
         for face in many_faces:
             x_min, y_min, x_max, y_max = face['bbox']
-            modules.globals.source_target_map.append({
-                'id' : i, 
-                'target' : {
-                            'cv2' : target_frame[int(y_min):int(y_max), int(x_min):int(x_max)],
-                            'face' : face
-                            }
-                })
+            with modules.globals.MAP_LOCK:
+                modules.globals.source_target_map.append({
+                    'id' : i,
+                    'target' : {
+                                'cv2' : target_frame[int(y_min):int(y_max), int(x_min):int(x_max)],
+                                'face' : face
+                                }
+                    })
             i = i + 1
     except ValueError:
         return None
@@ -106,10 +110,11 @@ def get_unique_faces_from_target_image() -> Any:
     
 def get_unique_faces_from_target_video() -> Any:
     try:
-        modules.globals.source_target_map = []
+        with modules.globals.MAP_LOCK:
+            modules.globals.source_target_map = []
         frame_face_embeddings = []
         face_embeddings = []
-    
+
         print('Creating temp resources...')
         clean_temp(modules.globals.target_path)
         create_temp(modules.globals.target_path)
@@ -125,7 +130,7 @@ def get_unique_faces_from_target_video() -> Any:
 
             for face in many_faces:
                 face_embeddings.append(face.normed_embedding)
-            
+
             frame_face_embeddings.append({'frame': i, 'faces': many_faces, 'location': temp_frame_path})
             i += 1
 
@@ -137,15 +142,17 @@ def get_unique_faces_from_target_video() -> Any:
                 face['target_centroid'] = closest_centroid_index
 
         for i in range(len(centroids)):
-            modules.globals.source_target_map.append({
-                'id' : i
-            })
+            with modules.globals.MAP_LOCK:
+                modules.globals.source_target_map.append({
+                    'id' : i
+                })
 
             temp = []
             for frame in tqdm(frame_face_embeddings, desc=f"Mapping frame embeddings to centroids-{i}"):
                 temp.append({'frame': frame['frame'], 'faces': [face for face in frame['faces'] if face['target_centroid'] == i], 'location': frame['location']})
 
-            modules.globals.source_target_map[i]['target_faces_in_frame'] = temp
+            with modules.globals.MAP_LOCK:
+                modules.globals.source_target_map[i]['target_faces_in_frame'] = temp
 
         # dump_faces(centroids, frame_face_embeddings)
         default_target_face()

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -1,6 +1,7 @@
 # --- START OF FILE globals.py ---
 
 import os
+import threading
 from typing import List, Dict, Any
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -14,6 +15,7 @@ file_types = [
 # Face Mapping Data
 source_target_map: List[Dict[str, Any]] = [] # Stores detailed map for image/video processing
 simple_map: Dict[str, Any] = {}             # Stores simplified map (embeddings/faces) for live/simple mode
+MAP_LOCK = threading.Lock()                 # Protects source_target_map and simple_map mutations
 
 # Paths
 source_path: str | None = None


### PR DESCRIPTION
## Summary

`source_target_map` and `simple_map` in `modules/globals.py` are mutated from the UI thread (when the user configures face mappings) and read concurrently from `ThreadPoolExecutor` workers during frame processing. Without synchronization, this causes intermittent crashes or corrupted map state during live mode with map-faces enabled.

This adds a `threading.Lock()` to `globals.py` and wraps all mutations of these shared data structures in `face_analyser.py`.

## Changes

- `modules/globals.py`: Add `MAP_LOCK = threading.Lock()`
- `modules/face_analyser.py`: Wrap mutations of `source_target_map` and `simple_map` with `MAP_LOCK`

## Testing

- Map-faces mode: configure mappings while live preview is running
- Verify no crashes during concurrent map updates and frame processing
- Standard face swap (non-map mode) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Protect global face-mapping state from concurrent modifications by introducing a shared lock and using it around all map mutations.

Bug Fixes:
- Prevent race conditions and intermittent crashes when updating face-mapping data while it is being read during frame processing.

Enhancements:
- Guard global face-mapping structures with a dedicated lock to ensure thread-safe updates from UI and worker threads.