### PR TITLE
fix(core): restrict setrlimit to Linux only

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -161,7 +161,7 @@ def limit_resources() -> None:
             import ctypes
             kernel32 = ctypes.windll.kernel32
             kernel32.SetProcessWorkingSetSize(-1, ctypes.c_size_t(memory), ctypes.c_size_t(memory))
-        else:
+        elif platform.system().lower() == 'linux':
             import resource
             resource.setrlimit(resource.RLIMIT_DATA, (memory, memory))
 


### PR DESCRIPTION
## Summary

`limit_resources()` calls `resource.setrlimit(resource.RLIMIT_DATA, ...)` in the `else` branch for all non-Windows platforms. On macOS, `RLIMIT_DATA` is not supported — it's either silently ignored or raises an error depending on the Python/OS version.

This changes the `else` to `elif platform.system().lower() == 'linux'` so the call only runs where it's actually effective.

## Changes

- `modules/core.py`: Change `else` to `elif platform.system().lower() == 'linux'` in `limit_resources()`

## Testing

- macOS: `limit_resources()` no longer calls `setrlimit` (was no-op anyway)
- Linux: Behavior unchanged — `setrlimit` still called
- Windows: Behavior unchanged — uses `SetProcessWorkingSetSize`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Avoid calling resource.setrlimit with RLIMIT_DATA on non-Linux platforms where it may be unsupported or ineffective.