### PR TITLE
fix(security): reject output filenames starting with dash

### DIFF
--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -235,6 +235,10 @@ def normalize_output_path(source_path: str, target_path: str, output_path: str) 
             return os.path.join(
                 output_path, source_name + "-" + target_name + target_extension
             )
+    if output_path and os.path.basename(output_path).startswith("-"):
+        raise ValueError(
+            f"Output filename must not start with '-': {os.path.basename(output_path)}"
+        )
     return output_path
 
 


### PR DESCRIPTION
## Summary

Filenames starting with `-` are interpreted as command-line flags by ffmpeg. If a user provides a crafted output filename like `-filter_complex <malicious_filter>`, it could be passed to ffmpeg as arguments rather than a filename, allowing for argument injection attacks.

This adds validation in `normalize_output_path()` to reject output filenames that start with `-`.

## Changes

- `modules/utilities.py`: Add validation in `normalize_output_path()` to raise `ValueError` for dash-prefixed filenames

## Testing

- `normalize_output_path("src.jpg", "tgt.mp4", "/out/dir")` → works normally
- `normalize_output_path("src.jpg", "tgt.mp4", "-evil.mp4")` → raises `ValueError`
- Normal filenames with dashes in the middle still work: `my-output.mp4`

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Reject output filenames whose basename starts with '-' in normalize_output_path() to prevent them being interpreted as ffmpeg command-line flags.