### PR TITLE
fix(utilities): require dot prefix in has_image_extension checks

### DIFF
--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -261,7 +261,7 @@ def clean_temp(target_path: str) -> None:
 
 
 def has_image_extension(image_path: str) -> bool:
-    return image_path.lower().endswith(("png", "jpg", "jpeg"))
+    return image_path.lower().endswith((".png", ".jpg", ".jpeg"))
 
 
 def is_image(image_path: str) -> bool:


### PR DESCRIPTION
## Summary

`has_image_extension()` uses `endswith(("png", "jpg", "jpeg"))` without dot prefixes, so any path ending in those letters matches (e.g., `notapng` → `True`).

This adds the `.` prefix to each extension tuple entry so only actual file extensions match.

## Changes

- `modules/utilities.py`: Add `.` prefix to extension strings in `has_image_extension()`

## Testing

- `has_image_extension("photo.png")` → `True` (unchanged)
- `has_image_extension("notapng")` → `False` (was incorrectly `True`)
- `has_image_extension("file.jpg")` → `True` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure has_image_extension() only matches real file extensions (e.g., .png, .jpg, .jpeg) instead of any path ending with those letter sequences.