### PR TITLE
fix(core): correct macOS memory limit from exabytes to gigabytes

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -161,7 +161,7 @@ def limit_resources() -> None:
     if modules.globals.max_memory:
         memory = modules.globals.max_memory * 1024 ** 3
         if platform.system().lower() == 'darwin':
-            memory = modules.globals.max_memory * 1024 ** 6
+            memory = modules.globals.max_memory * 1024 ** 3
         if platform.system().lower() == 'windows':
             import ctypes
             kernel32 = ctypes.windll.kernel32


### PR DESCRIPTION
## Summary
- Fix `limit_resources()` using `1024 ** 6` (exabytes) instead of `1024 ** 3` (gigabytes) on macOS
- The macOS-specific branch overwrites the correct initial calculation with a value ~1 billion times too large
- With default `max_memory=4`, this sets a 4 EB limit instead of 4 GB, making the limit effectively useless

## Changes
- `modules/core.py`: Change `1024 ** 6` to `1024 ** 3` in the macOS branch of `limit_resources()`

## Test plan
- [ ] Verify memory limit is correctly applied on macOS (4 GB default)
- [ ] Verify Windows and Linux paths are unchanged
- [ ] Run application with `--max-memory 8` and verify limit takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix macOS-specific memory limit in limit_resources() to apply the configured max_memory in gigabytes rather than exabytes.