### PR TITLE
perf(processors): remove unnecessary frame copy in post-processing

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -296,7 +296,7 @@ def apply_post_processing(current_frame: Frame, swapped_face_bboxes: List[np.nda
     """Applies sharpening and interpolation with Apple Silicon optimizations."""
     global PREVIOUS_FRAME_RESULT
 
-    processed_frame = current_frame.copy()
+    processed_frame = current_frame
 
     # 1. Apply Sharpening (if enabled) with optimized kernel for Apple Silicon
     sharpness_value = getattr(modules.globals, "sharpness", 0.0)


### PR DESCRIPTION
## Summary
- Remove unnecessary `numpy.copy()` of the frame in post-processing
- Reduces memory allocations per frame, improving throughput
- Especially beneficial at high resolutions

## Test plan
- [ ] Verify face swapping output is identical (no visual artifacts)
- [ ] Check memory usage reduction with large frames
- [ ] Confirm no side effects from in-place frame modification

Generated with Claude Code

## Summary by Sourcery

Enhancements:
- Reduce per-frame memory allocations by operating directly on the original frame during post-processing.