### PR TITLE
perf: add NumPy Apple Accelerate BLAS detection on startup

### DIFF
--- a/modules/blas_check.py
+++ b/modules/blas_check.py
@@ -1,0 +1,86 @@
+"""Detect and report NumPy BLAS configuration on Apple Silicon.
+
+This module checks if NumPy is using Apple Accelerate BLAS on macOS ARM64.
+If not, it provides guidance on how to build NumPy with Accelerate BLAS.
+"""
+import sys
+import platform
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def get_numpy_blas_info():
+    """Get BLAS configuration information from NumPy.
+
+    Returns:
+        dict: Contains 'uses_accelerate' (bool), 'blas_type' (str), 'config' (str)
+    """
+    import numpy as np
+
+    # Get full config output (not just string representation)
+    import io
+    import contextlib
+
+    f = io.StringIO()
+    with contextlib.redirect_stdout(f):
+        np.show_config()
+    config_str = f.getvalue().lower()
+
+    blas_type = "unknown"
+    uses_accelerate = False
+
+    if "accelerate" in config_str or "veclib" in config_str:
+        blas_type = "accelerate"
+        uses_accelerate = True
+    elif "openblas" in config_str:
+        blas_type = "openblas"
+        uses_accelerate = False
+    elif "mkl" in config_str:
+        blas_type = "mkl"
+        uses_accelerate = False
+
+    return {
+        "uses_accelerate": uses_accelerate,
+        "blas_type": blas_type,
+        "config": config_str,
+    }
+
+
+def check_apple_silicon_blas():
+    """Check if running on Apple Silicon and validate BLAS configuration.
+
+    On Apple Silicon (macOS ARM64):
+    - Logs a warning if NumPy is not using Accelerate BLAS
+    - Returns True if Accelerate is in use, False otherwise
+
+    On other platforms:
+    - Returns None (not applicable)
+
+    Returns:
+        bool or None: True/False on Apple Silicon, None on other platforms
+    """
+    if sys.platform != "darwin" or platform.machine() != "arm64":
+        return None
+
+    info = get_numpy_blas_info()
+
+    if not info["uses_accelerate"]:
+        logger.warning(
+            "NumPy on Apple Silicon is using %s instead of Apple Accelerate BLAS. "
+            "To improve performance, rebuild NumPy with Accelerate support.",
+            info["blas_type"],
+        )
+        return False
+
+    logger.info("NumPy is using Apple Accelerate BLAS on Apple Silicon")
+    return True
+
+
+def log_blas_config():
+    """Log full NumPy BLAS configuration for debugging."""
+    info = get_numpy_blas_info()
+    logger.debug("NumPy BLAS Type: %s", info["blas_type"])
+    logger.debug("Uses Accelerate: %s", info["uses_accelerate"])
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug("Full config:\n%s", info["config"])

--- a/modules/core.py
+++ b/modules/core.py
@@ -24,6 +24,7 @@ import modules.metadata
 import modules.ui as ui
 from modules.processors.frame.core import get_frame_processors_modules
 from modules.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp, normalize_output_path
+from modules.blas_check import check_apple_silicon_blas
 
 if HAS_TORCH and 'ROCMExecutionProvider' in modules.globals.execution_providers:
     del torch
@@ -181,6 +182,7 @@ def pre_check() -> bool:
     if not shutil.which('ffmpeg'):
         update_status('ffmpeg is not installed.')
         return False
+    check_apple_silicon_blas()
     return True
 
 


### PR DESCRIPTION
## Summary
- Add BLAS detection module that checks NumPy's backend on startup
- Warn Apple Silicon users if NumPy is using OpenBLAS instead of Apple Accelerate
- Apple Accelerate can provide up to 10x speedup for linear algebra operations
- Detection is lightweight and only runs once at startup

## Test plan
- [ ] Verify warning appears on macOS ARM with OpenBLAS NumPy
- [ ] Verify no warning on non-macOS platforms
- [ ] Verify no warning when Accelerate is in use
- [ ] Confirm startup time is not noticeably affected

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Apple Silicon-specific NumPy BLAS configuration check at startup and optimize face enhancement processing concurrency and early-exit behavior.

New Features:
- Introduce a BLAS detection module that inspects NumPy's backend and reports configuration on Apple Silicon.
- Add a startup pre-check that validates NumPy BLAS usage on macOS ARM64 and logs guidance when Apple Accelerate is not used.

Enhancements:
- Increase concurrent GFPGAN face enhancement processing based on CPU core count to better utilize multi-core hardware.
- Add a lightweight pre-detection step in the face enhancement pipeline to skip expensive enhancement on frames without detected faces.