### PR TITLE
perf(face-enhancer): increase semaphore count and skip redundant face detection

### DIFF
--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -20,7 +20,11 @@ from modules.utilities import (
 )
 
 FACE_ENHANCER = None
-THREAD_SEMAPHORE = threading.Semaphore()
+# Allow up to min(cpu_count, 8) concurrent GFPGAN calls to better utilise multi-core hardware.
+# A value of 1 (the previous default) serialised all enhancement and left cores idle.
+# Cap at 8 to avoid saturating VRAM on systems with many cores.
+_SEMAPHORE_COUNT = min(max(1, (os.cpu_count() or 1)), 8)
+THREAD_SEMAPHORE = threading.Semaphore(_SEMAPHORE_COUNT)
 THREAD_LOCK = threading.Lock()
 NAME = "DLC.FACE-ENHANCER"
 
@@ -314,7 +318,22 @@ def enhance_face(temp_frame: Frame) -> Frame:
 
 
 def process_frame(source_face: Face | None, temp_frame: Frame) -> Frame:
-    """Processes a frame: enhances face if detected."""
+    """Processes a frame: enhances face if detected.
+
+    We run a lightweight InsightFace detection before calling GFPGAN to avoid
+    paying the full GFPGAN inference cost on frames that contain no face.
+    GFPGAN runs its own internal detection, so this is a redundant detection,
+    but it is cheap compared to the full enhancement pass and allows early-exit
+    on face-free frames.
+
+    TODO: if the frame processor pipeline is ever refactored to pass detected
+    face bounding boxes between stages, the InsightFace call here can be
+    replaced by reusing the bboxes produced by face_swapper, eliminating the
+    redundancy entirely.
+    """
+    target_face = get_one_face(temp_frame)
+    if target_face is None:
+        return temp_frame
     temp_frame = enhance_face(temp_frame)
     return temp_frame
 


### PR DESCRIPTION
## Summary
- Increase face enhancer semaphore from 1 to `min(cpu_count, 8)` for multi-core throughput (previously serialized all enhancement and left cores idle)
- Add lightweight `get_one_face()` pre-check before expensive GFPGAN pass — early-exits on frames with no faces, avoiding the full enhancement cost
- **Note:** this adds a new InsightFace detection call (not reusing swapper results); the savings come from skipping the expensive GFPGAN inference on face-free frames. The added detection is cheap compared to the full enhancement pass.

## Test plan
- [ ] Verify face enhancement quality is unchanged
- [ ] Test with multiple faces in frame (many-faces mode)
- [ ] Monitor VRAM usage to ensure no OOM with increased semaphore count
- [ ] Check FPS improvement with face_enhancer enabled
- [ ] Verify frames without faces are efficiently skipped

Generated with [Claude Code](https://claude.com/claude-code)