### PR TITLE
perf(face-swapper): add warmup inference call after CoreML model load

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -116,6 +116,28 @@ def get_face_swapper() -> Any:
                     providers=providers_config,
                 )
                 update_status("Face swapper model loaded successfully.", NAME)
+                # Warmup inference: trigger CoreML JIT compilation and compute plan
+                # caching so the first real inference call has no latency spike.
+                if any(
+                    (p[0] if isinstance(p, tuple) else p) == "CoreMLExecutionProvider"
+                    for p in providers_config
+                ):
+                    try:
+                        session = FACE_SWAPPER.session
+                        input_feed = {
+                            inp.name: np.zeros(
+                                [d if isinstance(d, int) and d > 0 else 1
+                                 for d in inp.shape],
+                                dtype=np.float32,
+                            )
+                            for inp in session.get_inputs()
+                        }
+                        session.run(None, input_feed)
+                        update_status("CoreML warmup inference complete.", NAME)
+                    except Exception as warmup_err:
+                        update_status(
+                            f"CoreML warmup skipped (non-fatal): {warmup_err}", NAME
+                        )
             except Exception as e:
                 update_status(f"Error loading face swapper model: {e}", NAME)
                 FACE_SWAPPER = None


### PR DESCRIPTION
## Summary
- CoreML lazily compiles/optimizes the model on first inference, causing a visible stall
- Add a warmup inference call with dummy data immediately after model load
- Moves the compilation cost to startup, making the first real frame swap instant

## Test plan
- [ ] Verify first frame swap has no visible delay on macOS with CoreML provider
- [ ] Verify no regression on other execution providers (CUDA, CPU)
- [ ] Confirm startup time increase is acceptable (< 2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Warm up the CoreML-based face swapper model after loading and adjust macOS camera enumeration to improve stability.

New Features:
- Add a CoreML warmup inference pass for the face swapper model to eliminate first-frame latency spikes.

Bug Fixes:
- Change macOS camera detection to probe a limited range of indices to avoid AVFoundation-related crashes when enumerating cameras.

Enhancements:
- Shift CoreML model compilation cost to startup so subsequent face swap inferences respond without visible delay.