### PR TITLE
perf: use cached face detection in map-faces live mode

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -482,7 +482,7 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
 
     else:
         # Live stream or webcam processing (analyze faces on the fly)
-        detected_faces = get_many_faces(processed_frame)
+        detected_faces = get_faces_optimized(processed_frame)
         if detected_faces:
             if modules.globals.many_faces:
                  source_face = default_source_face() # Use default source for all detected targets


### PR DESCRIPTION
## Summary

Switch `process_frame_v2()` live path from `get_many_faces()` to `get_faces_optimized()` so map-faces live mode benefits from time-based detection caching, matching the simple-mode live path.

`get_faces_optimized()` returns cached results when called within the detection interval (~33ms), avoiding redundant face detection on consecutive frames. This was already used in the simple (non-map) live mode but the map-faces live branch was still calling `get_many_faces()` directly.

### Files changed
- `modules/processors/frame/face_swapper.py` — 1 line: `get_many_faces` → `get_faces_optimized` in the live stream branch of `process_frame_v2()`

Inspired by #1617.

## Test plan
- [ ] Run live webcam with map-faces mode enabled (multiple source faces mapped to targets)
- [ ] Verify face detection caching is active (reduced CPU/GPU usage for detection)
- [ ] Confirm face swapping still works correctly with cached detection results
- [ ] Test with single-face and multi-face scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Route live map-faces processing through the optimized face detection function to reuse recent detection results and reduce redundant work.