### PR TITLE
fix(security): remove SSL bypass, log silent errors, add checksum validation

### DIFF
--- a/modules/processors/frame/face_masking.py
+++ b/modules/processors/frame/face_masking.py
@@ -1,8 +1,12 @@
+import logging
+
 import cv2
 import numpy as np
 from modules.typing import Face, Frame
 import modules.globals
 from modules.gpu_processing import gpu_gaussian_blur, gpu_resize, gpu_cvt_color
+
+logger = logging.getLogger(__name__)
 
 def apply_color_transfer(source, target):
     """
@@ -498,7 +502,7 @@ def apply_mask_area(
 
         frame[min_y:max_y, min_x:max_x] = final_blend.astype(np.uint8)
     except Exception as e:
-        print(f"face_masking: blending failed, returning unmodified frame: {e}")
+        logger.warning("face_masking: blending failed, returning unmodified frame: %s", e)
 
     return frame
 

--- a/modules/processors/frame/face_masking.py
+++ b/modules/processors/frame/face_masking.py
@@ -498,7 +498,7 @@ def apply_mask_area(
 
         frame[min_y:max_y, min_x:max_x] = final_blend.astype(np.uint8)
     except Exception as e:
-        pass
+        print(f"face_masking: blending failed, returning unmodified frame: {e}")
 
     return frame
 

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -1,5 +1,6 @@
 import glob
 import hashlib
+import logging
 import mimetypes
 import os
 import platform
@@ -11,6 +12,8 @@ from typing import List, Any
 from tqdm import tqdm
 
 import modules.globals
+
+logger = logging.getLogger(__name__)
 
 TEMP_FILE = "temp.mp4"
 TEMP_DIRECTORY = "temp"
@@ -40,7 +43,7 @@ def run_ffmpeg(args: List[str]) -> bool:
         subprocess.check_output(commands, stderr=subprocess.STDOUT)
         return True
     except Exception as e:
-        print(f"run_ffmpeg: command failed: {e}")
+        logger.error("run_ffmpeg: command failed: %s", e)
     return False
 
 
@@ -62,7 +65,7 @@ def detect_fps(target_path: str) -> float:
         numerator, denominator = map(int, output)
         return numerator / denominator
     except Exception as e:
-        print(f"detect_fps: could not parse frame rate from {target_path!r}: {e}, defaulting to 30.0")
+        logger.warning("detect_fps: could not parse frame rate from %r: %s, defaulting to 30.0", target_path, e)
     return 30.0
 
 
@@ -177,7 +180,7 @@ def create_video(target_path: str, fps: float = 30.0) -> None:
     
     if not success and encoder in ['h264_nvenc', 'hevc_nvenc', 'h264_amf', 'hevc_amf']:
         # Fallback to software encoding
-        print(f"Hardware encoding with {encoder} failed, falling back to software encoding...")
+        logger.warning("Hardware encoding with %s failed, falling back to software encoding...", encoder)
         fallback_encoder = 'libx264' if 'h264' in encoder else 'libx265'
         ffmpeg_args_fallback = [
             "-r", str(fps),
@@ -283,7 +286,7 @@ def is_video(video_path: str) -> bool:
     return False
 
 
-def conditional_download(download_directory_path: str, urls: List[str], expected_checksums: dict | None = None) -> None:
+def conditional_download(download_directory_path: str, urls: List[str], *, expected_checksums: dict | None = None) -> None:
     if not os.path.exists(download_directory_path):
         os.makedirs(download_directory_path)
     for url in urls:
@@ -301,11 +304,11 @@ def conditional_download(download_directory_path: str, urls: List[str], expected
                 unit_divisor=1024,
             ) as progress:
                 urllib.request.urlretrieve(url, download_file_path, reporthook=lambda count, block_size, total_size: progress.update(block_size))  # type: ignore[attr-defined]
-            # Verify checksum if one was registered for this file
-            filename = os.path.basename(url)
-            if expected_checksums and filename in expected_checksums:
-                expected = expected_checksums[filename]
+            # Verify checksum if one was registered for this URL
+            if expected_checksums and url in expected_checksums:
+                expected = expected_checksums[url]
                 actual = _compute_sha256(download_file_path)
+                filename = os.path.basename(url)
                 if actual != expected:
                     os.remove(download_file_path)
                     raise ValueError(
@@ -313,7 +316,7 @@ def conditional_download(download_directory_path: str, urls: List[str], expected
                         f"expected {expected!r}, got {actual!r}. "
                         f"File deleted — please retry the download."
                     )
-                print(f"conditional_download: checksum verified for {filename!r}")
+                logger.info("conditional_download: checksum verified for %r", filename)
 
 
 def resolve_relative_path(path: str) -> str:

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -1,9 +1,9 @@
 import glob
+import hashlib
 import mimetypes
 import os
 import platform
 import shutil
-import ssl
 import subprocess
 import urllib
 from pathlib import Path
@@ -15,9 +15,14 @@ import modules.globals
 TEMP_FILE = "temp.mp4"
 TEMP_DIRECTORY = "temp"
 
-# monkey patch ssl for mac
-if platform.system().lower() == "darwin":
-    ssl._create_default_https_context = ssl._create_unverified_context
+
+def _compute_sha256(file_path: str) -> str:
+    """Compute SHA-256 hash of a file, reading in 1 MiB chunks to handle large models."""
+    h = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
 
 
 def run_ffmpeg(args: List[str]) -> bool:
@@ -34,8 +39,8 @@ def run_ffmpeg(args: List[str]) -> bool:
     try:
         subprocess.check_output(commands, stderr=subprocess.STDOUT)
         return True
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"run_ffmpeg: command failed: {e}")
     return False
 
 
@@ -56,8 +61,8 @@ def detect_fps(target_path: str) -> float:
     try:
         numerator, denominator = map(int, output)
         return numerator / denominator
-    except Exception:
-        pass
+    except Exception as e:
+        print(f"detect_fps: could not parse frame rate from {target_path!r}: {e}, defaulting to 30.0")
     return 30.0
 
 
@@ -278,7 +283,7 @@ def is_video(video_path: str) -> bool:
     return False
 
 
-def conditional_download(download_directory_path: str, urls: List[str]) -> None:
+def conditional_download(download_directory_path: str, urls: List[str], expected_checksums: dict | None = None) -> None:
     if not os.path.exists(download_directory_path):
         os.makedirs(download_directory_path)
     for url in urls:
@@ -296,6 +301,19 @@ def conditional_download(download_directory_path: str, urls: List[str]) -> None:
                 unit_divisor=1024,
             ) as progress:
                 urllib.request.urlretrieve(url, download_file_path, reporthook=lambda count, block_size, total_size: progress.update(block_size))  # type: ignore[attr-defined]
+            # Verify checksum if one was registered for this file
+            filename = os.path.basename(url)
+            if expected_checksums and filename in expected_checksums:
+                expected = expected_checksums[filename]
+                actual = _compute_sha256(download_file_path)
+                if actual != expected:
+                    os.remove(download_file_path)
+                    raise ValueError(
+                        f"Checksum mismatch for {filename!r}: "
+                        f"expected {expected!r}, got {actual!r}. "
+                        f"File deleted — please retry the download."
+                    )
+                print(f"conditional_download: checksum verified for {filename!r}")
 
 
 def resolve_relative_path(path: str) -> str:


### PR DESCRIPTION
## Summary
- Remove macOS `ssl._create_unverified_context` monkey-patch — SSL certificate verification is now enabled on all platforms
- `run_ffmpeg()` and `detect_fps()` now print errors instead of silently swallowing them
- `face_masking.apply_mask_area()` logs blending failures before returning the unmodified frame
- Add `_compute_sha256()` helper and `expected_checksums` parameter to `conditional_download()` — mismatched files are deleted and `ValueError` raised

Replaces #1658 (closed — wrong branch content).

## Test plan
- [ ] Verify model downloads succeed with SSL verification enabled
- [ ] Confirm checksum validation catches corrupted downloads
- [ ] Test face masking error path returns unmodified frame
- [ ] Run ffmpeg operations and verify errors are logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten download and processing security by enabling SSL verification, adding checksum validation for downloaded files, and surfacing previously silent processing errors.

New Features:
- Add SHA-256 checksum computation helper and optional expected_checksums support to conditional_download() to validate downloaded files.

Bug Fixes:
- Remove macOS-specific SSL context monkey-patch so HTTPS certificate verification is enforced consistently.
- Ensure run_ffmpeg() reports command failures instead of failing silently.
- Ensure detect_fps() logs parsing errors before falling back to a default frame rate.
- Ensure face_masking.apply_mask_area() logs blending failures before returning the original frame.