### PR TITLE
Switch to FP32 model by default, add run script

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -54,11 +54,11 @@ def pre_check() -> bool:
         logging.error(f"Failed to create directory {download_directory_path} due to permission error: {e}")
         return False
     
-    # Use the direct download URL from Hugging Face
+    # Use the direct download URL from Hugging Face (FP32 model for broad GPU compatibility)
     conditional_download(
         download_directory_path,
         [
-            "https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx"
+            "https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128.onnx"
         ],
     )
     return True
@@ -85,9 +85,9 @@ def get_face_swapper() -> Any:
 
     with THREAD_LOCK:
         if FACE_SWAPPER is None:
+            # Use FP32 model by default for broad GPU compatibility.
+            # FP16 can produce NaN on GPUs without Tensor Cores (e.g. GTX 16xx).
             model_name = "inswapper_128.onnx"
-            if "CUDAExecutionProvider" in modules.globals.execution_providers:
-                model_name = "inswapper_128_fp16.onnx"
             model_path = os.path.join(models_dir, model_name)
             update_status(f"Loading face swapper model from: {model_path}", NAME)
             try:

--- a/run.py
+++ b/run.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
 
+import os
+import sys
+
+# Add the project root to PATH so bundled ffmpeg/ffprobe are found
+project_root = os.path.dirname(os.path.abspath(__file__))
+os.environ["PATH"] = project_root + os.pathsep + os.environ.get("PATH", "")
+
+# Add NVIDIA CUDA DLL directories to PATH so onnxruntime-gpu can find them
+nvidia_dir = os.path.join(project_root, "venv", "Lib", "site-packages", "nvidia")
+if os.path.isdir(nvidia_dir):
+    for pkg in os.listdir(nvidia_dir):
+        bin_dir = os.path.join(nvidia_dir, pkg, "bin")
+        if os.path.isdir(bin_dir):
+            os.environ["PATH"] = bin_dir + os.pathsep + os.environ["PATH"]
+
 # Import the tkinter fix to patch the ScreenChanged error
 import tkinter_fix
 


### PR DESCRIPTION
Change default face swapper model to FP32 for better GPU compatibility and avoid NaN issues on certain GPUs.
Revamped `run.py` to adjust PATH variables for dependencies setup and re-added with expanded configuration.

## Summary by Sourcery

Switch the default face swapper to use the FP32 ONNX model and reintroduce an updated run script for configuring and launching the application.

New Features:
- Add a run script that configures environment paths and exposes expanded runtime configuration.

Enhancements:
- Default the face swapper to the FP32 ONNX model for broader GPU compatibility and more stable inference on non-Tensor Core GPUs.