### PR TITLE
fix(#1640): add null checks for cv2.imread() results

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -87,7 +87,19 @@ def get_unique_faces_from_target_image() -> Any:
     try:
         modules.globals.source_target_map = []
         target_frame = cv2.imread(modules.globals.target_path)
+        
+        # Fix #1640: Check if image was loaded successfully
+        if target_frame is None:
+            print(f"Error: Could not read image from {modules.globals.target_path}")
+            return None
+            
         many_faces = get_many_faces(target_frame)
+        
+        # Check if faces were detected
+        if many_faces is None:
+            print("Warning: No faces detected in target image")
+            return None
+            
         i = 0
 
         for face in many_faces:
@@ -121,7 +133,17 @@ def get_unique_faces_from_target_video() -> Any:
         i = 0
         for temp_frame_path in tqdm(temp_frame_paths, desc="Extracting face embeddings from frames"):
             temp_frame = cv2.imread(temp_frame_path)
+            
+            # Fix #1640: Skip frames that couldn't be read
+            if temp_frame is None:
+                print(f"Warning: Could not read frame from {temp_frame_path}")
+                continue
+                
             many_faces = get_many_faces(temp_frame)
+            
+            # Skip frames with no faces detected
+            if many_faces is None:
+                continue
 
             for face in many_faces:
                 face_embeddings.append(face.normed_embedding)

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -3,7 +3,7 @@ import shutil
 from typing import Any
 import insightface
 import threading
-
+import logging
 import cv2
 import numpy as np
 import modules.globals
@@ -12,6 +12,8 @@ from modules.typing import Frame
 from modules.cluster_analysis import find_cluster_centroids, find_closest_centroid
 from modules.utilities import get_temp_directory_path, create_temp, extract_frames, clean_temp, get_temp_frame_paths
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 FACE_ANALYSER = None
 FACE_ANALYSER_LOCK = threading.Lock()
@@ -84,24 +86,31 @@ def add_blank_map() -> Any:
         return None
     
 def get_unique_faces_from_target_image() -> Any:
+    """
+    Extract unique faces from target image for mapping.
+    
+    Returns:
+        None on success (populates modules.globals.source_target_map)
+        None on error or no faces detected
+    """
     try:
         modules.globals.source_target_map = []
         target_frame = cv2.imread(modules.globals.target_path)
         
-        # Fix #1640: Check if image was loaded successfully
+        # Fix #1640: Validate image was loaded successfully
         if target_frame is None:
-            print(f"Error: Could not read image from {modules.globals.target_path}")
+            logger.warning(f"Could not read image from {modules.globals.target_path}. "
+                          f"Ensure the file exists and is a valid image format.")
             return None
             
         many_faces = get_many_faces(target_frame)
         
-        # Check if faces were detected
-        if many_faces is None:
-            print("Warning: No faces detected in target image")
+        # Handle case where no faces detected (empty list)
+        if not many_faces:  # Works for both None and empty list
+            logger.warning("No faces detected in target image.")
             return None
             
         i = 0
-
         for face in many_faces:
             x_min, y_min, x_max, y_max = face['bbox']
             modules.globals.source_target_map.append({
@@ -112,11 +121,19 @@ def get_unique_faces_from_target_image() -> Any:
                             }
                 })
             i = i + 1
+            
     except ValueError:
+        logger.error("Error processing target image", exc_info=True)
         return None
-    
-    
+
 def get_unique_faces_from_target_video() -> Any:
+    """
+    Extract unique faces from target video for mapping using clustering.
+    
+    Returns:
+        None on success (populates modules.globals.source_target_map)
+        None on error or no faces detected
+    """
     try:
         modules.globals.source_target_map = []
         frame_face_embeddings = []
@@ -136,13 +153,13 @@ def get_unique_faces_from_target_video() -> Any:
             
             # Fix #1640: Skip frames that couldn't be read
             if temp_frame is None:
-                print(f"Warning: Could not read frame from {temp_frame_path}")
+                logger.debug(f"Could not read frame from {temp_frame_path}, skipping.")
                 continue
                 
             many_faces = get_many_faces(temp_frame)
             
-            # Skip frames with no faces detected
-            if many_faces is None:
+            # Skip frames with no faces detected (handles empty list)
+            if not many_faces:
                 continue
 
             for face in many_faces:
@@ -150,6 +167,11 @@ def get_unique_faces_from_target_video() -> Any:
             
             frame_face_embeddings.append({'frame': i, 'faces': many_faces, 'location': temp_frame_path})
             i += 1
+
+        # Check if any faces were found across all frames
+        if not frame_face_embeddings:
+            logger.warning("No faces detected across any frame in target video.")
+            return None
 
         centroids = find_cluster_centroids(face_embeddings)
 
@@ -171,9 +193,10 @@ def get_unique_faces_from_target_video() -> Any:
 
         # dump_faces(centroids, frame_face_embeddings)
         default_target_face()
+        
     except ValueError:
+        logger.error("Error processing target video", exc_info=True)
         return None
-    
 
 def default_target_face():
     for map in modules.globals.source_target_map:

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -107,6 +107,11 @@ def get_unique_faces_from_target_image() -> Any:
         
         # Handle case where no faces detected (empty list)
         if not many_faces:  # Works for both None and empty list
+            logger.warning(
+                f"No faces detected in target image {modules.globals.target_path}. "
+                f"Ensure the image contains at least one detectable face."
+            )
+            return None
             logger.warning("No faces detected in target image.")
             return None
             


### PR DESCRIPTION
## Problem
When an image file cannot be read by OpenCV (e.g., wrong format, no extension), `cv2.imread()` returns `None`. The code then passes this `None` value to `get_many_faces()`, which eventually tries to access `.shape` on the `None` value, causing `AttributeError: 'NoneType' object has no attribute 'shape'`.

User reported images named "1" and "2" (no extension) triggered this issue.

## Solution
- Added null check after `cv2.imread()` in `get_unique_faces_from_target_image()`
- Added null check after `cv2.imread()` in `get_unique_faces_from_target_video()`  
- Skip invalid frames with warning message instead of crashing
- Gracefully handle cases where no faces are detected

## Testing
Tested with:
- Images with invalid/no file extension
- Non-existent files
- Valid image files (should work as before)

## Closes
#1640

## Summary by Sourcery

Handle unreadable images and videos in face analysis without crashing by validating cv2.imread() results and gracefully aborting when no faces are found.

Bug Fixes:
- Prevent AttributeError by checking for None results from cv2.imread() before passing frames to face detection.
- Skip unreadable video frames and frames without detected faces instead of causing failures during face extraction.
- Gracefully handle cases where no faces are detected in target images or across all video frames.

Enhancements:
- Add logging to report unreadable images, skipped frames, missing faces, and processing errors in target media.