### PR TITLE
Fix macOS SIGSEGV crash in live webcam mode (tkinter thread-safety)

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1347,8 +1347,9 @@ def create_webcam_preview(camera_index: int):
 
         ROOT.after(16, _display_next_frame)
 
-    # Kick off the non-blocking display loop
-    ROOT.after(0, _display_next_frame)
+    # Kick off the non-blocking display loop (small delay to let PREVIEW
+    # finish deiconify before the first state check)
+    ROOT.after(100, _display_next_frame)
 
 
 def create_source_target_popup_for_webcam(

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -751,16 +751,36 @@ def create_preview(parent: ctk.CTkToplevel) -> ctk.CTkToplevel:
 
 
 def update_status(text: str) -> None:
-    status_label.configure(text=_(text))
-    ROOT.update()
+    translated = _(text)
+
+    def _do():
+        if status_label is not None:
+            status_label.configure(text=translated)
+
+    if ROOT is not None:
+        ROOT.after(0, _do)
 
 
 def update_pop_status(text: str) -> None:
-    popup_status_label.configure(text=_(text))
+    translated = _(text)
+
+    def _do():
+        if popup_status_label is not None and POPUP is not None and POPUP.winfo_exists():
+            popup_status_label.configure(text=translated)
+
+    if ROOT is not None:
+        ROOT.after(0, _do)
 
 
 def update_pop_live_status(text: str) -> None:
-    popup_status_label_live.configure(text=_(text))
+    translated = _(text)
+
+    def _do():
+        if popup_status_label_live is not None and POPUP_LIVE is not None and POPUP_LIVE.winfo_exists():
+            popup_status_label_live.configure(text=translated)
+
+    if ROOT is not None:
+        ROOT.after(0, _do)
 
 
 def update_tumbler(var: str, value: bool) -> None:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -757,7 +757,7 @@ def update_status(text: str) -> None:
         if status_label is not None:
             status_label.configure(text=translated)
 
-    if ROOT is not None:
+    if ROOT is not None and ROOT.winfo_exists():
         ROOT.after(0, _do)
 
 
@@ -768,7 +768,7 @@ def update_pop_status(text: str) -> None:
         if popup_status_label is not None and POPUP is not None and POPUP.winfo_exists():
             popup_status_label.configure(text=translated)
 
-    if ROOT is not None:
+    if ROOT is not None and ROOT.winfo_exists():
         ROOT.after(0, _do)
 
 
@@ -779,7 +779,7 @@ def update_pop_live_status(text: str) -> None:
         if popup_status_label_live is not None and POPUP_LIVE is not None and POPUP_LIVE.winfo_exists():
             popup_status_label_live.configure(text=translated)
 
-    if ROOT is not None:
+    if ROOT is not None and ROOT.winfo_exists():
         ROOT.after(0, _do)
 
 


### PR DESCRIPTION
## Summary
- Fix `SIGSEGV` crash (`Tk_FreeGC` → `TkButtonWorldChanged` → `ConfigureButton`) that occurs on macOS when starting live webcam mode
- Replace direct tkinter widget updates from background threads with `ROOT.after(0, ...)` to schedule UI changes on the main Tk event loop
- Remove `ROOT.update()` call from `update_status()` which re-enters the Tk event loop from background threads

## Problem
On macOS (tested on Apple Silicon M2 Max, macOS 26.3.1), clicking "Live" in the webcam preview causes an immediate crash with:
```
Exception Type: EXC_BAD_ACCESS (SIGSEGV)
Thread 18 Crashed:
0 libtcl9tk9.0.dylib Tk_FreeGC + 24
1 libtcl9tk9.0.dylib TkButtonWorldChanged + 104
2 libtcl9tk9.0.dylib ConfigureButton + 2200
```

This happens because `update_status()`, `update_pop_status()`, and `update_pop_live_status()` call `widget.configure()` directly from background threads. Tkinter is not thread-safe on macOS, and modifying widgets from non-main threads causes segfaults in Tk's graphics context management.

## Fix
- Use `ROOT.after(0, callback)` to schedule all widget updates on the main Tk thread
- Add null/existence guards to prevent crashes if widgets are destroyed before the callback executes
- Remove `ROOT.update()` from `update_status()` (unnecessary with `ROOT.after()` and dangerous from background threads)

## Test plan
- [ ] Launch `python run.py` on macOS
- [ ] Select a source face image
- [ ] Click "Live" → should no longer crash
- [ ] Verify status messages still update in the UI
- [ ] Test on Linux/Windows to confirm no regression

## Summary by Sourcery

Route tkinter status label updates through the main Tk event loop to prevent macOS crashes when updating the UI from background threads.

Bug Fixes:
- Prevent SIGSEGV crashes on macOS live webcam mode caused by updating tkinter widgets from background threads.

Enhancements:
- Schedule status and popup label updates via the Tk root event loop and add existence checks to avoid updating destroyed widgets.