### PR TITLE
fix: add missing logging import and fix invalid get_one_face call in face_swapper

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional
 import cv2
 import insightface
+import logging
 import threading
 import numpy as np
 import platform
@@ -517,7 +518,7 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
                                      source_target_pairs.append((source_faces[i], detected_faces_with_embedding[closest_idx]))
             else: # Fallback: if no map, use default source for the single detected face (if any)
                 source_face = default_source_face()
-                target_face = get_one_face(processed_frame, detected_faces) # Use faces already detected
+                target_face = min(detected_faces, key=lambda x: x.bbox[0]) if detected_faces else None
                 if source_face and target_face:
                     source_target_pairs.append((source_face, target_face))
 


### PR DESCRIPTION
## What

Two bugs in `modules/processors/frame/face_swapper.py`:

**Bug 1 — Missing `logging` import causes `NameError`**

In `pre_check()`, if `os.makedirs()` raises an `OSError` (e.g. permission denied), the code calls `logging.error(...)` but `logging` was never imported. This triggers a secondary `NameError: name 'logging' is not defined`, masking the original error and making it very hard to diagnose.

Fix: add `import logging` to the imports.

**Bug 2 — `get_one_face` called with two arguments**

In the live-stream fallback path of `process_frame_v2` (line ~521):

```python
target_face = get_one_face(processed_frame, detected_faces)
```

`get_one_face` only accepts **one** argument (`frame`), so this raises a `TypeError` at runtime. Faces have already been detected into `detected_faces` at this point, so there's no need to call the analyser again. The fix reuses the already-detected list with the same selection logic (`min` by `bbox[0]`) that `get_one_face` uses internally, avoiding both the crash and a redundant detection pass.

## Test plan

- [ ] Start the app in live/webcam mode with `--map-faces` omitted (simple mode), to exercise the fallback path in `process_frame_v2`.
- [ ] Verify no `TypeError` is raised when a face is detected in the live feed.
- [ ] Simulate a permission-denied scenario on the models directory and confirm the error is logged correctly instead of raising `NameError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix runtime errors in the face swapper fallback path and improve error logging for directory creation failures.

Bug Fixes:
- Import the logging module so pre_check can log directory creation errors without raising a NameError.
- Correct the live-stream fallback in process_frame_v2 to select a detected face directly instead of calling get_one_face with an invalid signature.