### PR TITLE
fix: unify face swapper model path selection

### DIFF
--- a/modules/processors/frame/_face_swapper_model.py
+++ b/modules/processors/frame/_face_swapper_model.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 
 PREFERRED_FACE_SWAPPER_MODELS = (
@@ -7,10 +8,12 @@ PREFERRED_FACE_SWAPPER_MODELS = (
 )
 
 
-def resolve_face_swapper_model_path(models_dir: str) -> str:
-    for filename in PREFERRED_FACE_SWAPPER_MODELS:
-        model_path = os.path.join(models_dir, filename)
-        if os.path.exists(model_path):
-            return model_path
+def resolve_face_swapper_model_path(models_dir: str | os.PathLike[str]) -> str:
+    models_path = Path(models_dir)
 
-    return os.path.join(models_dir, PREFERRED_FACE_SWAPPER_MODELS[0])
+    for filename in PREFERRED_FACE_SWAPPER_MODELS:
+        model_path = models_path / filename
+        if model_path.exists():
+            return str(model_path)
+
+    return str(models_path / PREFERRED_FACE_SWAPPER_MODELS[0])

--- a/modules/processors/frame/_face_swapper_model.py
+++ b/modules/processors/frame/_face_swapper_model.py
@@ -1,0 +1,16 @@
+import os
+
+
+PREFERRED_FACE_SWAPPER_MODELS = (
+    "inswapper_128.onnx",
+    "inswapper_128_fp16.onnx",
+)
+
+
+def resolve_face_swapper_model_path(models_dir: str) -> str:
+    for filename in PREFERRED_FACE_SWAPPER_MODELS:
+        model_path = os.path.join(models_dir, filename)
+        if os.path.exists(model_path):
+            return model_path
+
+    return os.path.join(models_dir, PREFERRED_FACE_SWAPPER_MODELS[0])

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -14,6 +14,7 @@ from modules.utilities import (
     is_image,
     is_video,
 )
+from modules.processors.frame._face_swapper_model import resolve_face_swapper_model_path
 from modules.cluster_analysis import find_closest_centroid
 from modules.gpu_processing import gpu_gaussian_blur, gpu_sharpen, gpu_add_weighted, gpu_resize, gpu_cvt_color
 import os
@@ -66,7 +67,7 @@ def pre_check() -> bool:
 
 def pre_start() -> bool:
     # Simplified pre_start, assuming checks happen before calling process functions
-    model_path = os.path.join(models_dir, "inswapper_128_fp16.onnx")
+    model_path = resolve_face_swapper_model_path(models_dir)
     if not os.path.exists(model_path):
         update_status(f"Model not found: {model_path}. Please download it.", NAME)
         return False
@@ -87,8 +88,7 @@ def get_face_swapper() -> Any:
         if FACE_SWAPPER is None:
             # Use FP32 model by default for broad GPU compatibility.
             # FP16 can produce NaN on GPUs without Tensor Cores (e.g. GTX 16xx).
-            model_name = "inswapper_128.onnx"
-            model_path = os.path.join(models_dir, model_name)
+            model_path = resolve_face_swapper_model_path(models_dir)
             update_status(f"Loading face swapper model from: {model_path}", NAME)
             try:
                 # Optimized provider configuration for Apple Silicon

--- a/tests/test_face_swapper_model.py
+++ b/tests/test_face_swapper_model.py
@@ -1,22 +1,19 @@
 import tempfile
+import types
 import unittest
-import importlib.util
 from pathlib import Path
+import sys
 
 
-MODULE_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "modules"
-    / "processors"
-    / "frame"
-    / "_face_swapper_model.py"
-)
-SPEC = importlib.util.spec_from_file_location("_face_swapper_model", MODULE_PATH)
-if SPEC is None or SPEC.loader is None:
-    raise RuntimeError(f"Unable to load module from {MODULE_PATH}")
-MODULE = importlib.util.module_from_spec(SPEC)
-SPEC.loader.exec_module(MODULE)
-resolve_face_swapper_model_path = MODULE.resolve_face_swapper_model_path
+fake_cv2 = types.ModuleType("cv2")
+fake_cv2.__dict__["IMREAD_COLOR"] = 1
+_ = sys.modules.setdefault("cv2", fake_cv2)
+
+fake_numpy = types.ModuleType("numpy")
+fake_numpy.__dict__["uint8"] = object()
+_ = sys.modules.setdefault("numpy", fake_numpy)
+
+from modules.processors.frame._face_swapper_model import resolve_face_swapper_model_path
 
 
 class FaceSwapperModelPathTests(unittest.TestCase):
@@ -26,7 +23,7 @@ class FaceSwapperModelPathTests(unittest.TestCase):
             (model_dir / "inswapper_128.onnx").write_text("fp32")
             (model_dir / "inswapper_128_fp16.onnx").write_text("fp16")
 
-            result = resolve_face_swapper_model_path(str(model_dir))
+            result = resolve_face_swapper_model_path(model_dir)
 
             self.assertEqual(result, str(model_dir / "inswapper_128.onnx"))
 

--- a/tests/test_face_swapper_model.py
+++ b/tests/test_face_swapper_model.py
@@ -1,0 +1,52 @@
+import tempfile
+import unittest
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "modules"
+    / "processors"
+    / "frame"
+    / "_face_swapper_model.py"
+)
+SPEC = importlib.util.spec_from_file_location("_face_swapper_model", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"Unable to load module from {MODULE_PATH}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+resolve_face_swapper_model_path = MODULE.resolve_face_swapper_model_path
+
+
+class FaceSwapperModelPathTests(unittest.TestCase):
+    def test_prefers_fp32_model_when_present(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_dir = Path(temp_dir)
+            (model_dir / "inswapper_128.onnx").write_text("fp32")
+            (model_dir / "inswapper_128_fp16.onnx").write_text("fp16")
+
+            result = resolve_face_swapper_model_path(str(model_dir))
+
+            self.assertEqual(result, str(model_dir / "inswapper_128.onnx"))
+
+    def test_falls_back_to_fp16_model_when_fp32_is_missing(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_dir = Path(temp_dir)
+            (model_dir / "inswapper_128_fp16.onnx").write_text("fp16")
+
+            result = resolve_face_swapper_model_path(str(model_dir))
+
+            self.assertEqual(result, str(model_dir / "inswapper_128_fp16.onnx"))
+
+    def test_returns_default_fp32_target_when_no_model_exists(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            model_dir = Path(temp_dir)
+
+            result = resolve_face_swapper_model_path(str(model_dir))
+
+            self.assertEqual(result, str(model_dir / "inswapper_128.onnx"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- unify face swapper model selection so the app uses the same resolved model path in both pre-start validation and runtime loading
- prefer `inswapper_128.onnx` when it exists, but cleanly fall back to the documented `inswapper_128_fp16.onnx`
- add a focused regression test for fp32 preference, fp16 fallback, and the default missing-file target

Fixes #1628.
Addresses #1633.

## Testing
- `python3 -m unittest tests.test_face_swapper_model`
- `python3 -m py_compile modules/processors/frame/_face_swapper_model.py modules/processors/frame/face_swapper.py tests/test_face_swapper_model.py`

## Summary by Sourcery

Unify face swapper model path resolution between startup validation and runtime loading while preferring the FP32 model with a clear fallback strategy.

New Features:
- Introduce a shared resolver utility to determine the face swapper model path based on available model files.

Bug Fixes:
- Ensure pre-start validation and runtime loading use the same face swapper model selection logic to avoid mismatched model expectations.

Enhancements:
- Prefer the FP32 face swapper model when available and fall back to the FP16 model or a sensible default path when missing.

Tests:
- Add unit tests covering FP32 preference, FP16 fallback, and the default target when no model files are present.