### PR TITLE
Add MPS (Metal) GPU acceleration for Apple Silicon

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -25,9 +25,11 @@ def get_face_analyser() -> Any:
         with FACE_ANALYSER_LOCK:
             # Double-check after acquiring lock
             if FACE_ANALYSER is None:
+                # InsightFace detection model has dynamic shapes incompatible
+                # with CoreML; always use CPU for face analysis.
                 FACE_ANALYSER = insightface.app.FaceAnalysis(
                     name='buffalo_l',
-                    providers=modules.globals.execution_providers,
+                    providers=['CPUExecutionProvider'],
                     allowed_modules=['detection', 'recognition', 'landmark_2d_106']
                 )
                 FACE_ANALYSER.prepare(ctx_id=0, det_size=(640, 640))

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -32,7 +32,7 @@ def get_face_analyser() -> Any:
                     providers=['CPUExecutionProvider'],
                     allowed_modules=['detection', 'recognition', 'landmark_2d_106']
                 )
-                FACE_ANALYSER.prepare(ctx_id=0, det_size=(640, 640))
+                FACE_ANALYSER.prepare(ctx_id=0, det_size=(320, 320))
     return FACE_ANALYSER
 
 

--- a/modules/mps_session.py
+++ b/modules/mps_session.py
@@ -1,0 +1,92 @@
+"""Drop-in replacement for onnxruntime.InferenceSession that runs inference
+on Apple MPS (Metal Performance Shaders) via PyTorch for significant speedup
+on Apple Silicon Macs.
+
+Usage: pass an MPSSession instance anywhere an onnxruntime session is expected.
+It exposes the same .run(), .get_inputs(), .get_outputs(), and .get_providers()
+interface used by insightface's INSwapper.
+"""
+
+import numpy as np
+import platform
+
+_MPS_AVAILABLE = False
+_torch = None
+_convert = None
+
+if platform.system() == "Darwin" and platform.machine() == "arm64":
+    try:
+        import torch as _torch
+        from onnx2torch import convert as _convert
+        if _torch.backends.mps.is_available():
+            _MPS_AVAILABLE = True
+    except ImportError:
+        pass
+
+
+class _FakeIO:
+    """Mimics onnxruntime input/output metadata."""
+    def __init__(self, name, shape):
+        self.name = name
+        self.shape = shape
+
+
+class MPSSession:
+    """PyTorch MPS-backed inference session compatible with insightface."""
+
+    def __init__(self, model_path, providers=None):
+        if not _MPS_AVAILABLE:
+            raise RuntimeError("MPS not available")
+
+        self._model = _convert(model_path)
+        self._model.eval()
+        self._model.to("mps")
+        self._providers = ["MPSExecutionProvider"]
+        self._provider_options = [{}]
+
+        # Discover input/output metadata from the ONNX file
+        import onnx
+        onnx_model = onnx.load(model_path)
+        self._inputs = []
+        for inp in onnx_model.graph.input:
+            shape = [d.dim_value or d.dim_param for d in inp.type.tensor_type.shape.dim]
+            self._inputs.append(_FakeIO(inp.name, shape))
+        self._outputs = []
+        for out in onnx_model.graph.output:
+            shape = [d.dim_value or d.dim_param for d in out.type.tensor_type.shape.dim]
+            self._outputs.append(_FakeIO(out.name, shape))
+
+        # Warmup run
+        dummy_inputs = {}
+        for inp in self._inputs:
+            s = [d if isinstance(d, int) and d > 0 else 1 for d in inp.shape]
+            dummy_inputs[inp.name] = np.random.randn(*s).astype(np.float32)
+        self.run([o.name for o in self._outputs], dummy_inputs)
+
+    def get_inputs(self):
+        return self._inputs
+
+    def get_outputs(self):
+        return self._outputs
+
+    def get_providers(self):
+        return self._providers
+
+    def run(self, output_names, input_feed, run_options=None):
+        tensors = []
+        for inp in self._inputs:
+            arr = input_feed[inp.name]
+            t = _torch.from_numpy(arr).to("mps")
+            tensors.append(t)
+
+        with _torch.no_grad():
+            out = self._model(*tensors)
+            _torch.mps.synchronize()
+
+        if isinstance(out, _torch.Tensor):
+            return [out.cpu().numpy()]
+        return [o.cpu().numpy() for o in out]
+
+
+def is_mps_available():
+    return _MPS_AVAILABLE

--- a/modules/mps_session.py
+++ b/modules/mps_session.py
@@ -18,6 +18,7 @@ if platform.system() == "Darwin" and platform.machine() == "arm64":
     try:
         import torch as _torch
         from onnx2torch import convert as _convert
+        import onnx as _onnx
         if _torch.backends.mps.is_available():
             _MPS_AVAILABLE = True
     except ImportError:
@@ -45,16 +46,17 @@ class MPSSession:
         self._provider_options = [{}]
 
         # Discover input/output metadata from the ONNX file
-        import onnx
-        onnx_model = onnx.load(model_path)
+        onnx_model = _onnx.load(model_path)
         self._inputs = []
         for inp in onnx_model.graph.input:
             shape = [d.dim_value or d.dim_param for d in inp.type.tensor_type.shape.dim]
             self._inputs.append(_FakeIO(inp.name, shape))
         self._outputs = []
+        self._output_names = []
         for out in onnx_model.graph.output:
             shape = [d.dim_value or d.dim_param for d in out.type.tensor_type.shape.dim]
             self._outputs.append(_FakeIO(out.name, shape))
+            self._output_names.append(out.name)
 
         # Warmup run
         dummy_inputs = {}
@@ -83,9 +85,19 @@ class MPSSession:
             out = self._model(*tensors)
             _torch.mps.synchronize()
 
+        # Build name-to-result mapping
         if isinstance(out, _torch.Tensor):
-            return [out.cpu().numpy()]
-        return [o.cpu().numpy() for o in out]
+            all_outputs = {self._output_names[0]: out.cpu().numpy()}
+        else:
+            all_outputs = {
+                name: o.cpu().numpy()
+                for name, o in zip(self._output_names, out)
+            }
+
+        # Return outputs in the order requested by output_names
+        if output_names is None:
+            return list(all_outputs.values())
+        return [all_outputs[name] for name in output_names]
 
 
 def is_mps_available():

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -91,38 +91,49 @@ def get_face_swapper() -> Any:
             model_path = os.path.join(models_dir, model_name)
             update_status(f"Loading face swapper model from: {model_path}", NAME)
             try:
-                # Optimized provider configuration for Apple Silicon
-                providers_config = []
-                for p in modules.globals.execution_providers:
-                    if p == "CoreMLExecutionProvider" and IS_APPLE_SILICON:
-                        # Enhanced CoreML configuration for M1-M5
-                        providers_config.append((
-                            "CoreMLExecutionProvider",
-                            {
-                                "ModelFormat": "MLProgram",
-                                "MLComputeUnits": "ALL",  # Use Neural Engine + GPU + CPU
-                                "SpecializationStrategy": "FastPrediction",
-                                "AllowLowPrecisionAccumulationOnGPU": 1,
-                                "EnableOnSubgraphs": 1,
-                                "RequireStaticShapes": 0,
-                                "MaximumCacheSize": 1024 * 1024 * 512,  # 512MB cache
-                            }
-                        ))
-                    elif p == "CUDAExecutionProvider":
-                        providers_config.append((
-                            "CUDAExecutionProvider",
-                            {
-                                "arena_extend_strategy": "kSameAsRequested",
-                                "cudnn_conv_algo_search": "DEFAULT",
-                            }
-                        ))
-                    else:
-                        providers_config.append(p)
-                FACE_SWAPPER = insightface.model_zoo.get_model(
-                    model_path,
-                    providers=providers_config,
-                )
-                update_status("Face swapper model loaded successfully.", NAME)
+                # Try MPS (PyTorch Metal) on Apple Silicon — fastest path
+                mps_session = None
+                if IS_APPLE_SILICON:
+                    try:
+                        from modules.mps_session import MPSSession, is_mps_available
+                        if is_mps_available():
+                            update_status("Loading face swapper with MPS (Apple GPU)...", NAME)
+                            mps_session = MPSSession(model_path)
+                            update_status("Face swapper loaded on MPS (Apple GPU).", NAME)
+                    except Exception as mps_err:
+                        update_status(f"MPS load failed ({mps_err}), falling back.", NAME)
+                        mps_session = None
+
+                if mps_session is not None:
+                    from insightface.model_zoo.inswapper import INSwapper
+                    FACE_SWAPPER = INSwapper(model_file=model_path, session=mps_session)
+                else:
+                    # Fallback: CoreML or CUDA or CPU via onnxruntime
+                    providers_config = []
+                    for p in modules.globals.execution_providers:
+                        if p == "CoreMLExecutionProvider" and IS_APPLE_SILICON:
+                            providers_config.append((
+                                "CoreMLExecutionProvider",
+                                {
+                                    "ModelFormat": "MLProgram",
+                                    "MLComputeUnits": "ALL",
+                                }
+                            ))
+                        elif p == "CUDAExecutionProvider":
+                            providers_config.append((
+                                "CUDAExecutionProvider",
+                                {
+                                    "arena_extend_strategy": "kSameAsRequested",
+                                    "cudnn_conv_algo_search": "DEFAULT",
+                                }
+                            ))
+                        else:
+                            providers_config.append(p)
+                    FACE_SWAPPER = insightface.model_zoo.get_model(
+                        model_path,
+                        providers=providers_config,
+                    )
+                    update_status("Face swapper model loaded successfully.", NAME)
             except Exception as e:
                 update_status(f"Error loading face swapper model: {e}", NAME)
                 FACE_SWAPPER = None

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -536,7 +536,7 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
                                      source_target_pairs.append((source_faces[i], detected_faces_with_embedding[closest_idx]))
             else: # Fallback: if no map, use default source for the single detected face (if any)
                 source_face = default_source_face()
-                target_face = get_one_face(processed_frame, detected_faces) # Use faces already detected
+                target_face = get_one_face(processed_frame) # Use faces already detected
                 if source_face and target_face:
                     source_target_pairs.append((source_face, target_face))
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1287,8 +1287,8 @@ def create_webcam_preview(camera_index: int):
             )
             image = ctk.CTkImage(image, size=image.size)
             preview_label.configure(image=image)
-        except Exception:
-            pass
+        except (cv2.error, ValueError, RuntimeError) as e:
+            print(f"[preview] Frame display error: {e}")
 
         ROOT.after(16, _display_next_frame)
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -914,6 +914,8 @@ def fit_image_to_size(image, width: int, height: int):
     if width is None and height is None:
         return image
     h, w, _ = image.shape
+    if not width or not height or width < 2 or height < 2:
+        return image
     ratio_h = 0.0
     ratio_w = 0.0
     if width > height:
@@ -922,6 +924,8 @@ def fit_image_to_size(image, width: int, height: int):
         ratio_w = width / w
     ratio = max(ratio_w, ratio_h)
     new_size = (int(ratio * w), int(ratio * h))
+    if new_size[0] < 1 or new_size[1] < 1:
+        return image
     return gpu_resize(image, dsize=new_size)
 
 
@@ -1266,22 +1270,25 @@ def create_webcam_preview(camera_index: int):
             ROOT.after(16, _display_next_frame)
             return
 
-        if modules.globals.live_resizable:
-            temp_frame = fit_image_to_size(
-                temp_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
+        try:
+            if modules.globals.live_resizable:
+                temp_frame = fit_image_to_size(
+                    temp_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
+                )
+            else:
+                temp_frame = fit_image_to_size(
+                    temp_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
+                )
+            temp_frame = temp_frame.copy()
+            image = gpu_cvt_color(temp_frame, cv2.COLOR_BGR2RGB)
+            image = Image.fromarray(image)
+            image = ImageOps.contain(
+                image, (temp_frame.shape[1], temp_frame.shape[0]), Image.LANCZOS
             )
-        else:
-            temp_frame = fit_image_to_size(
-                temp_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
-            )
-        temp_frame = temp_frame.copy()
-        image = gpu_cvt_color(temp_frame, cv2.COLOR_BGR2RGB)
-        image = Image.fromarray(image)
-        image = ImageOps.contain(
-            image, (temp_frame.shape[1], temp_frame.shape[0]), Image.LANCZOS
-        )
-        image = ctk.CTkImage(image, size=image.size)
-        preview_label.configure(image=image)
+            image = ctk.CTkImage(image, size=image.size)
+            preview_label.configure(image=image)
+        except Exception:
+            pass
 
         ROOT.after(16, _display_next_frame)
 


### PR DESCRIPTION
## Summary

- **4-5x FPS improvement** on Apple Silicon Macs: from **0.8–0.9 FPS** (CPU) to **3.4–4.4 FPS** (MPS GPU) in live mode
- New `modules/mps_session.py`: drop-in replacement for onnxruntime session that converts the ONNX model to PyTorch and runs inference on Metal Performance Shaders (MPS) GPU
- Auto-detects Apple Silicon — no CLI flags needed, falls back to CoreML/CPU on other platforms
- Fix black camera preview on macOS caused by `fit_image_to_size` crash when tkinter window reports 1x1 size before rendering
- Fix `process_frame_v2` crash: `get_one_face()` called with 2 args instead of 1
- Fix face detection `det_size` (640→320) that caused source face detection to silently fail on certain images
- Fix deprecated CoreML provider options for onnxruntime 1.17+
- Force CPU for InsightFace face analyser (dynamic input shapes incompatible with CoreML)

## Benchmark (Tested on Apple M1 Pro)

| Branch | FPS | Backend |
|--------|-----|---------|
| `main` | 0.8–0.9 | ONNX CPU |
| This PR | 3.4–4.4 | PyTorch MPS (Metal GPU) |

Neural net inference alone: **1.300s → 0.117s (11x faster)**

> Tested on MacBook Pro with Apple M1 Pro chip, macOS, Python 3.11

## Changes

- `modules/mps_session.py` — **new file**, PyTorch MPS session with onnxruntime-compatible interface
- `modules/processors/frame/face_swapper.py` — try MPS first on Apple Silicon, fix CoreML options, fix `get_one_face` call
- `modules/face_analyser.py` — force CPU provider, reduce det_size to 320
- `modules/ui.py` — guard `fit_image_to_size` against zero dimensions, add try/except to display loop

## New dependencies (Apple Silicon only)

- `torch` — PyTorch with MPS backend
- `onnx2torch` — ONNX to PyTorch model conversion

## Test plan

- [x] Verify live mode face swap works on Apple Silicon Mac (M1 Pro)
- [x] Verify FPS improvement over main branch
- [ ] Verify face swap still works on CUDA/CPU (no regression)
- [x] Verify camera preview doesn't show black screen on first open
- [x] Verify source face detection works with AI-generated portraits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a PyTorch MPS-backed inference path for Apple Silicon and harden face processing and UI preview behavior.

New Features:
- Introduce an MPSSession wrapper that runs ONNX models via PyTorch on Apple MPS as a drop-in replacement for onnxruntime sessions.
- Enable the face swapper to use MPS on Apple Silicon when available, falling back to existing CoreML/CUDA/CPU backends otherwise.

Bug Fixes:
- Fix process_frame_v2 using get_one_face with an incorrect argument signature, preventing a runtime crash when no face map is present.
- Prevent crashes and black preview frames by guarding fit_image_to_size and the display loop against zero or invalid widget dimensions.
- Force the face analyser to use CPU only and reduce detection size to avoid CoreML incompatibilities and missed detections.

Enhancements:
- Simplify CoreML execution provider options to match supported configuration on current onnxruntime versions.