### PR TITLE
fix(ui): guard preview resize against empty camera frames

### DIFF
--- a/modules/_image_sizing.py
+++ b/modules/_image_sizing.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+import numpy as np
+
+from modules.gpu_processing import gpu_resize
+
+
+def _fallback_frame(width: int, height: int) -> np.ndarray:
+    safe_width = max(1, int(width))
+    safe_height = max(1, int(height))
+    return np.zeros((safe_height, safe_width, 3), dtype=np.uint8)
+
+
+def fit_image_to_size(
+    image: Optional[np.ndarray],
+    width: Optional[int],
+    height: Optional[int],
+    fallback_size: Tuple[int, int] = (640, 360),
+) -> np.ndarray:
+    if width is None and height is None:
+        return image
+
+    target_width = int(width) if width is not None else int(fallback_size[0])
+    target_height = int(height) if height is not None else int(fallback_size[1])
+
+    if image is None or not hasattr(image, "shape"):
+        return _fallback_frame(target_width, target_height)
+
+    if image.size == 0 or len(image.shape) < 2:
+        return _fallback_frame(target_width, target_height)
+
+    if target_width <= 0 or target_height <= 0:
+        return image
+
+    h, w = image.shape[:2]
+    if h <= 0 or w <= 0:
+        return _fallback_frame(target_width, target_height)
+
+    ratio_h = 0.0
+    ratio_w = 0.0
+    if target_width > target_height:
+        ratio_h = target_height / h
+    else:
+        ratio_w = target_width / w
+    ratio = max(ratio_w, ratio_h)
+    if ratio <= 0:
+        return image
+
+    new_size = (max(1, int(ratio * w)), max(1, int(ratio * h)))
+    return gpu_resize(image, dsize=new_size)

--- a/modules/_image_sizing.py
+++ b/modules/_image_sizing.py
@@ -20,6 +20,10 @@ def fit_image_to_size(
     fallback_size: Tuple[int, int] = (640, 360),
 ) -> np.ndarray:
     if width is None and height is None:
+        if image is None or not hasattr(image, "shape"):
+            return _fallback_frame(fallback_size[0], fallback_size[1])
+        if image.size == 0 or len(image.shape) < 2:
+            return _fallback_frame(fallback_size[0], fallback_size[1])
         return image
 
     target_width = int(width) if width is not None else int(fallback_size[0])

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -4,6 +4,7 @@ import customtkinter as ctk
 from typing import Callable, Tuple
 import cv2
 from modules.gpu_processing import gpu_cvt_color, gpu_resize, gpu_flip
+from modules._image_sizing import fit_image_to_size
 from PIL import Image, ImageOps
 import time
 import json
@@ -910,21 +911,6 @@ def check_and_ignore_nsfw(target, destroy: Callable = None) -> bool:
         return False
 
 
-def fit_image_to_size(image, width: int, height: int):
-    if width is None and height is None:
-        return image
-    h, w, _ = image.shape
-    ratio_h = 0.0
-    ratio_w = 0.0
-    if width > height:
-        ratio_h = height / h
-    else:
-        ratio_w = width / w
-    ratio = max(ratio_w, ratio_h)
-    new_size = (int(ratio * w), int(ratio * h))
-    return gpu_resize(image, dsize=new_size)
-
-
 def render_image_preview(image_path: str, size: Tuple[int, int]) -> ctk.CTkImage:
     image = Image.open(image_path)
     if size:
@@ -1533,4 +1519,3 @@ def update_webcam_target(
         else:
             update_pop_live_status("Face could not be detected in last upload!")
         return map
-

--- a/tests/test_image_sizing.py
+++ b/tests/test_image_sizing.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
+import importlib
 import sys
 import types
 import unittest
+from unittest import mock
 
 fake_numpy = types.ModuleType("numpy")
 setattr(fake_numpy, "uint8", int)
 
 
 class FakeArray:
-    def __init__(self, shape, dtype=int) -> None:
+    def __init__(self, shape, dtype=int, fill_value=0) -> None:
         self.shape = shape
         self.dtype = dtype
+        self.fill_value = fill_value
         size = 1
         for dim in shape:
             size *= dim
@@ -19,17 +22,16 @@ class FakeArray:
 
 
 def fake_zeros(shape, dtype=int):
-    return FakeArray(shape, dtype=dtype)
+    return FakeArray(shape, dtype=dtype, fill_value=0)
 
 
 def fake_empty(shape, dtype=int):
-    return FakeArray(shape, dtype=dtype)
+    return FakeArray(shape, dtype=dtype, fill_value=0)
 
 
 setattr(fake_numpy, "zeros", fake_zeros)
 setattr(fake_numpy, "empty", fake_empty)
 setattr(fake_numpy, "ndarray", FakeArray)
-sys.modules.setdefault("numpy", fake_numpy)
 
 fake_gpu_processing = types.ModuleType("modules.gpu_processing")
 
@@ -45,15 +47,21 @@ def fake_gpu_resize(src, dsize, fx=0.0, fy=0.0, interpolation=None):
 
 
 setattr(fake_gpu_processing, "gpu_resize", fake_gpu_resize)
-sys.modules.setdefault("modules.gpu_processing", fake_gpu_processing)
 
 fake_cv2 = types.ModuleType("cv2")
 setattr(fake_cv2, "IMREAD_COLOR", 1)
 setattr(fake_cv2, "imdecode", lambda *args, **kwargs: None)
 setattr(fake_cv2, "imencode", lambda *args, **kwargs: (True, types.SimpleNamespace(tofile=lambda *_: None)))
-sys.modules.setdefault("cv2", fake_cv2)
-
-from modules._image_sizing import fit_image_to_size  # noqa: E402
+with mock.patch.dict(
+    sys.modules,
+    {
+        "numpy": fake_numpy,
+        "modules.gpu_processing": fake_gpu_processing,
+        "cv2": fake_cv2,
+    },
+    clear=False,
+):
+    fit_image_to_size = importlib.import_module("modules._image_sizing").fit_image_to_size
 
 
 class FitImageToSizeTests(unittest.TestCase):
@@ -69,6 +77,7 @@ class FitImageToSizeTests(unittest.TestCase):
 
         self.assertEqual(resized.shape, (240, 320, 3))
         self.assertEqual(resized.dtype, fake_numpy.uint8)
+        self.assertEqual(resized.fill_value, 0)
 
     def test_returns_fallback_frame_for_empty_input(self) -> None:
         image = fake_empty((0, 0, 3), dtype=fake_numpy.uint8)
@@ -77,6 +86,32 @@ class FitImageToSizeTests(unittest.TestCase):
 
         self.assertEqual(resized.shape, (240, 320, 3))
         self.assertEqual(resized.dtype, fake_numpy.uint8)
+        self.assertEqual(resized.fill_value, 0)
+
+    def test_returns_fallback_frame_for_1d_input(self) -> None:
+        image = fake_empty((10,), dtype=fake_numpy.uint8)
+
+        resized = fit_image_to_size(image, 320, 240)
+
+        self.assertEqual(resized.shape, (240, 320, 3))
+        self.assertEqual(resized.dtype, fake_numpy.uint8)
+        self.assertEqual(resized.fill_value, 0)
+
+    def test_returns_fallback_frame_for_scalar_input(self) -> None:
+        image = fake_empty((), dtype=fake_numpy.uint8)
+
+        resized = fit_image_to_size(image, 320, 240)
+
+        self.assertEqual(resized.shape, (240, 320, 3))
+        self.assertEqual(resized.dtype, fake_numpy.uint8)
+        self.assertEqual(resized.fill_value, 0)
+
+    def test_returns_fallback_frame_when_size_is_not_provided_and_image_is_none(self) -> None:
+        resized = fit_image_to_size(None, None, None)
+
+        self.assertEqual(resized.shape, (360, 640, 3))
+        self.assertEqual(resized.dtype, fake_numpy.uint8)
+        self.assertEqual(resized.fill_value, 0)
 
     def test_preserves_original_frame_when_target_size_is_invalid(self) -> None:
         image = fake_zeros((12, 18, 3), dtype=fake_numpy.uint8)

--- a/tests/test_image_sizing.py
+++ b/tests/test_image_sizing.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+
+fake_numpy = types.ModuleType("numpy")
+setattr(fake_numpy, "uint8", int)
+
+
+class FakeArray:
+    def __init__(self, shape, dtype=int) -> None:
+        self.shape = shape
+        self.dtype = dtype
+        size = 1
+        for dim in shape:
+            size *= dim
+        self.size = size
+
+
+def fake_zeros(shape, dtype=int):
+    return FakeArray(shape, dtype=dtype)
+
+
+def fake_empty(shape, dtype=int):
+    return FakeArray(shape, dtype=dtype)
+
+
+setattr(fake_numpy, "zeros", fake_zeros)
+setattr(fake_numpy, "empty", fake_empty)
+setattr(fake_numpy, "ndarray", FakeArray)
+sys.modules.setdefault("numpy", fake_numpy)
+
+fake_gpu_processing = types.ModuleType("modules.gpu_processing")
+
+
+def fake_gpu_resize(src, dsize, fx=0.0, fy=0.0, interpolation=None):
+    if dsize and dsize != (0, 0):
+        width, height = dsize
+    else:
+        width = max(1, int(src.shape[1] * fx))
+        height = max(1, int(src.shape[0] * fy))
+    channels = src.shape[2] if len(src.shape) > 2 else 1
+    return FakeArray((height, width, channels), dtype=src.dtype)
+
+
+setattr(fake_gpu_processing, "gpu_resize", fake_gpu_resize)
+sys.modules.setdefault("modules.gpu_processing", fake_gpu_processing)
+
+fake_cv2 = types.ModuleType("cv2")
+setattr(fake_cv2, "IMREAD_COLOR", 1)
+setattr(fake_cv2, "imdecode", lambda *args, **kwargs: None)
+setattr(fake_cv2, "imencode", lambda *args, **kwargs: (True, types.SimpleNamespace(tofile=lambda *_: None)))
+sys.modules.setdefault("cv2", fake_cv2)
+
+from modules._image_sizing import fit_image_to_size  # noqa: E402
+
+
+class FitImageToSizeTests(unittest.TestCase):
+    def test_resizes_valid_frame_with_non_zero_result(self) -> None:
+        image = fake_zeros((100, 200, 3), dtype=fake_numpy.uint8)
+
+        resized = fit_image_to_size(image, 50, 50)
+
+        self.assertEqual(resized.shape[:2], (25, 50))
+
+    def test_returns_fallback_frame_for_none_input(self) -> None:
+        resized = fit_image_to_size(None, 320, 240)
+
+        self.assertEqual(resized.shape, (240, 320, 3))
+        self.assertEqual(resized.dtype, fake_numpy.uint8)
+
+    def test_returns_fallback_frame_for_empty_input(self) -> None:
+        image = fake_empty((0, 0, 3), dtype=fake_numpy.uint8)
+
+        resized = fit_image_to_size(image, 320, 240)
+
+        self.assertEqual(resized.shape, (240, 320, 3))
+        self.assertEqual(resized.dtype, fake_numpy.uint8)
+
+    def test_preserves_original_frame_when_target_size_is_invalid(self) -> None:
+        image = fake_zeros((12, 18, 3), dtype=fake_numpy.uint8)
+
+        resized = fit_image_to_size(image, 0, 240)
+
+        self.assertIs(resized, image)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- move preview frame sizing logic into a small helper module and keep the UI call site unchanged
- guard `fit_image_to_size` against `None`, empty frames, and invalid preview dimensions to avoid resize assertions
- return a safe black fallback frame when the camera feed is unavailable so preview/live does not crash
- add regression tests for valid resize, `None` input, empty input, and invalid target size handling

Fixes #1612.

## Testing
- `python3 -m unittest tests.test_image_sizing`
