### PR TITLE
fix: resolve 4 bugs found via code audit

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -876,7 +876,7 @@ def process_frame_v2(temp_frame: Frame, temp_frame_path: str = "") -> Frame:
                                      source_target_pairs.append((source_faces[i], detected_faces_with_embedding[closest_idx]))
             else: # Fallback: if no map, use default source for the single detected face (if any)
                 source_face = default_source_face()
-                target_face = get_one_face(processed_frame, detected_faces) # Use faces already detected
+                target_face = min(detected_faces, key=lambda x: x.bbox[0]) if detected_faces else None
                 if source_face and target_face:
                     source_target_pairs.append((source_face, target_face))
 


### PR DESCRIPTION
## Summary

Fixes four bugs discovered during a code audit of the face swapper and UI modules:

**1. Missing `logging` import** (`face_swapper.py`)
- `logging.error()` is called in `pre_check()` but `logging` was never imported
- Causes `NameError` when model directory creation fails

**2. Model filename mismatch** (`face_swapper.py`)
- `pre_check()` downloads `inswapper_128.onnx` (FP32)
- `get_face_swapper()` loads `inswapper_128.onnx` (FP32)
- But `pre_start()` checks for `inswapper_128_fp16.onnx` — a file that is never downloaded
- This causes `pre_start()` to always fail with "Model not found"

**3. VideoCapture resource leak** (`ui.py`)
- `render_video_preview()` only calls `capture.release()` on the failure path
- When a frame is successfully read, the function returns without releasing the capture
- Leaks file handles on every video preview render

**4. `get_one_face()` called with wrong arity** (`face_swapper.py`)
- Line 530 passes two arguments `(processed_frame, detected_faces)` but `get_one_face()` only accepts one
- Causes `TypeError` at runtime in the map_faces fallback path
- Fixed by selecting from the already-detected faces directly, which also avoids redundant face detection

## Test plan
- [ ] Verify `pre_check()` handles directory creation errors without NameError
- [ ] Verify `pre_start()` finds the correct model file after `pre_check()` downloads it
- [ ] Verify video preview doesn't leak file handles (check with `lsof` during preview)
- [ ] Verify map_faces fallback path works without TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix bugs in the face swapper model handling and face selection logic, and ensure video preview resources are correctly released.

Bug Fixes:
- Ensure face swapper startup checks for the same ONNX model file that is downloaded during pre-check.
- Fix the face swap fallback path by selecting from already-detected faces instead of calling a helper with an invalid signature.
- Release video capture resources on successful video preview rendering to avoid leaking file handles.