### PR TITLE
fix: guard against None best_face in default_target_face when no faces detected

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -179,6 +179,9 @@ def default_target_face():
                 best_frame = frame
                 break
 
+        if best_face is None:
+            continue  # No faces detected in this cluster — skip
+
         for frame in map['target_faces_in_frame']:
             for face in frame['faces']:
                 if face['det_score'] > best_face['det_score']:


### PR DESCRIPTION
Closes #1755

## Problem
`default_target_face()` in `modules/face_analyser.py` crashes with `TypeError: 'NoneType' object is not subscriptable` when a face cluster has no frames with detected faces. `best_face` remains `None` after the first loop, then the second loop tries to access `best_face['det_score']`.

## Fix
Added an early `continue` guard after the first loop — if `best_face is None`, we skip this cluster entirely instead of crashing.

```python
if best_face is None:
    continue  # No faces detected in this cluster — skip
```

This is a one-line defensive guard that prevents the crash with no behavior change for the normal (faces detected) path.

## Summary by Sourcery

Bug Fixes:
- Avoid a TypeError in default_target_face when processing face clusters that contain no detected faces.