### PR TITLE
Fix face masking for invalid frames

### DIFF
--- a/modules/processors/frame/face_masking.py
+++ b/modules/processors/frame/face_masking.py
@@ -33,6 +33,9 @@ def apply_color_transfer(source, target):
     return np.clip(result_bgr * 255.0, 0, 255).astype(np.uint8)
 
 def create_face_mask(face: Face, frame: Frame) -> np.ndarray:
+    if frame is None or not hasattr(frame, "shape") or len(frame.shape) < 2:
+        return np.zeros((0, 0), dtype=np.uint8)
+
     mask = np.zeros(frame.shape[:2], dtype=np.uint8)
     landmarks = face.landmark_2d_106
     if landmarks is not None:

--- a/tests/test_face_masking_mask.py
+++ b/tests/test_face_masking_mask.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_face_masking_module():
+    fake_numpy = types.ModuleType("numpy")
+
+    class FakeArray:
+        def __init__(self, shape, dtype=int) -> None:
+            self.shape = shape
+            self.dtype = dtype
+
+    def fake_zeros(shape, dtype=int):
+        return FakeArray(shape, dtype=dtype)
+
+    fake_numpy.ndarray = FakeArray
+    fake_numpy.zeros = fake_zeros
+    fake_numpy.uint8 = int
+
+    fake_cv2 = types.ModuleType("cv2")
+    fake_cv2.IMREAD_COLOR = 1
+    fake_cv2.imdecode = lambda *args, **kwargs: None
+    fake_cv2.imencode = lambda *args, **kwargs: (
+        True,
+        types.SimpleNamespace(tofile=lambda *_args: None),
+    )
+
+    fake_globals = types.ModuleType("modules.globals")
+
+    fake_gpu = types.ModuleType("modules.gpu_processing")
+    fake_gpu.gpu_gaussian_blur = lambda img, *args, **kwargs: img
+    fake_gpu.gpu_resize = lambda img, *args, **kwargs: img
+    fake_gpu.gpu_cvt_color = lambda img, *args, **kwargs: img
+
+    fake_typing = types.ModuleType("modules.typing")
+    fake_typing.Face = object
+    fake_typing.Frame = object
+
+    sys.modules.pop("modules.processors.frame.face_masking", None)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "cv2": fake_cv2,
+            "numpy": fake_numpy,
+            "modules.globals": fake_globals,
+            "modules.gpu_processing": fake_gpu,
+            "modules.typing": fake_typing,
+        },
+        clear=False,
+    ):
+        return importlib.import_module("modules.processors.frame.face_masking")
+
+
+class CreateFaceMaskTests(unittest.TestCase):
+    @staticmethod
+    def _dummy_face():
+        class DummyFace:
+            landmark_2d_106 = []
+
+        return DummyFace()
+
+    def assert_empty_mask(self, face_masking, frame) -> None:
+        result = face_masking.create_face_mask(self._dummy_face(), frame)
+        self.assertEqual(result.shape, (0, 0))
+        self.assertEqual(result.dtype, face_masking.np.uint8)
+
+    def test_create_face_mask_returns_empty_mask_when_frame_is_none(self) -> None:
+        face_masking = _load_face_masking_module()
+        self.assert_empty_mask(face_masking, None)
+
+    def test_create_face_mask_returns_empty_mask_when_frame_has_no_shape(self) -> None:
+        face_masking = _load_face_masking_module()
+        self.assert_empty_mask(face_masking, 123)
+
+    def test_create_face_mask_returns_empty_mask_when_frame_is_1d(self) -> None:
+        face_masking = _load_face_masking_module()
+        one_dimensional_frame = types.SimpleNamespace(shape=(10,))
+        self.assert_empty_mask(face_masking, one_dimensional_frame)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Return an empty mask when `face_masking.create_face_mask()` receives `None`, an object without `shape`, or a 1D frame.
- Add focused unit coverage with lightweight fakes so the invalid-frame path does not import heavy runtime dependencies.

## Validation
- `python3 -m unittest tests/test_face_masking_mask.py`
- `python3 -m py_compile modules/processors/frame/face_masking.py tests/test_face_masking_mask.py`
- `git diff --check`
- `bash /Users/ming/.openclaw/skills/code-change-delivery-contract/scripts/scan_delivery_blockers.sh`

## Summary by Sourcery

Handle invalid frame inputs in face masking and add focused tests for these edge cases.

Bug Fixes:
- Return an empty mask when face masking is invoked with None, objects lacking a shape attribute, or 1D frames to avoid errors on invalid input.

Tests:
- Add lightweight unit tests for create_face_mask that validate behavior for None, non-array, and 1D frame inputs without importing heavy runtime dependencies.