### PR TITLE
Fix target image face mapping for unreadable images

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -104,10 +104,12 @@ def get_unique_faces_from_target_image() -> Any:
         modules.globals.source_target_map = []
         target_frame = cv2.imread(modules.globals.target_path)
         if target_frame is None:
-            return None
+            print(f"Could not read target image: {modules.globals.target_path}")
+            return []
         many_faces = get_many_faces(target_frame)
         if many_faces is None:
-            return None
+            print(f"No faces detected in target image: {modules.globals.target_path}")
+            return []
         i = 0
 
         for face in many_faces:
@@ -120,8 +122,9 @@ def get_unique_faces_from_target_image() -> Any:
                             }
                 })
             i = i + 1
+        return modules.globals.source_target_map
     except ValueError:
-        return None
+        return []
     
     
 def get_unique_faces_from_target_video() -> Any:

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -103,7 +103,11 @@ def get_unique_faces_from_target_image() -> Any:
     try:
         modules.globals.source_target_map = []
         target_frame = cv2.imread(modules.globals.target_path)
+        if target_frame is None:
+            return None
         many_faces = get_many_faces(target_frame)
+        if many_faces is None:
+            return None
         i = 0
 
         for face in many_faces:

--- a/tests/test_face_analyser_target_image.py
+++ b/tests/test_face_analyser_target_image.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_face_analyser_module(target_frame=None, many_faces=None):
+    calls = {"get_many_faces": []}
+
+    fake_cv2 = types.ModuleType("cv2")
+    fake_cv2.IMREAD_COLOR = 1
+    fake_cv2.imread = lambda path: target_frame
+    fake_cv2.imdecode = lambda *args, **kwargs: None
+    fake_cv2.imencode = lambda *args, **kwargs: (
+        True,
+        types.SimpleNamespace(tofile=lambda *_args: None),
+    )
+
+    fake_numpy = types.ModuleType("numpy")
+    fake_numpy.fromfile = lambda *args, **kwargs: b""
+    fake_numpy.uint8 = int
+
+    fake_insightface = types.ModuleType("insightface")
+    fake_insightface.app = types.SimpleNamespace(FaceAnalysis=object)
+
+    fake_globals = types.ModuleType("modules.globals")
+    fake_globals.execution_providers = []
+    fake_globals.source_target_map = [{"id": 99}]
+    fake_globals.target_path = "target.png"
+
+    fake_cluster = types.ModuleType("modules.cluster_analysis")
+    fake_cluster.find_cluster_centroids = lambda *args, **kwargs: []
+    fake_cluster.find_closest_centroid = lambda *args, **kwargs: (0, 0)
+
+    fake_utilities = types.ModuleType("modules.utilities")
+    fake_utilities.get_temp_directory_path = lambda *args, **kwargs: ""
+    fake_utilities.create_temp = lambda *args, **kwargs: None
+    fake_utilities.extract_frames = lambda *args, **kwargs: None
+    fake_utilities.clean_temp = lambda *args, **kwargs: None
+    fake_utilities.get_temp_frame_paths = lambda *args, **kwargs: []
+
+    fake_typing = types.ModuleType("modules.typing")
+    fake_typing.Frame = object
+
+    fake_tqdm = types.ModuleType("tqdm")
+    fake_tqdm.tqdm = lambda items, *args, **kwargs: items
+
+    sys.modules.pop("modules.face_analyser", None)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "cv2": fake_cv2,
+            "insightface": fake_insightface,
+            "numpy": fake_numpy,
+            "modules.globals": fake_globals,
+            "modules.cluster_analysis": fake_cluster,
+            "modules.utilities": fake_utilities,
+            "modules.typing": fake_typing,
+            "tqdm": fake_tqdm,
+        },
+        clear=False,
+    ):
+        face_analyser = importlib.import_module("modules.face_analyser")
+        face_analyser.modules.globals = fake_globals
+
+        def fake_get_many_faces(frame):
+            calls["get_many_faces"].append(frame)
+            return many_faces
+
+        face_analyser.get_many_faces = fake_get_many_faces
+        return face_analyser, fake_globals, calls
+
+
+class TargetImageFaceAnalysisTests(unittest.TestCase):
+    def test_target_image_read_failure_clears_map_without_analyser_call(self) -> None:
+        face_analyser, fake_globals, calls = _load_face_analyser_module(
+            target_frame=None,
+            many_faces=[],
+        )
+
+        face_analyser.get_unique_faces_from_target_image()
+
+        self.assertEqual(fake_globals.source_target_map, [])
+        self.assertEqual(calls["get_many_faces"], [])
+
+    def test_target_image_none_faces_leaves_map_empty(self) -> None:
+        face_analyser, fake_globals, calls = _load_face_analyser_module(
+            target_frame=object(),
+            many_faces=None,
+        )
+
+        face_analyser.get_unique_faces_from_target_image()
+
+        self.assertEqual(fake_globals.source_target_map, [])
+        self.assertEqual(len(calls["get_many_faces"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_face_analyser_target_image.py
+++ b/tests/test_face_analyser_target_image.py
@@ -4,6 +4,8 @@ import importlib
 import sys
 import types
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from unittest import mock
 
 
@@ -81,10 +83,14 @@ class TargetImageFaceAnalysisTests(unittest.TestCase):
             many_faces=[],
         )
 
-        face_analyser.get_unique_faces_from_target_image()
+        output = StringIO()
+        with redirect_stdout(output):
+            result = face_analyser.get_unique_faces_from_target_image()
 
+        self.assertEqual(result, [])
         self.assertEqual(fake_globals.source_target_map, [])
         self.assertEqual(calls["get_many_faces"], [])
+        self.assertIn("Could not read target image: target.png", output.getvalue())
 
     def test_target_image_none_faces_leaves_map_empty(self) -> None:
         face_analyser, fake_globals, calls = _load_face_analyser_module(
@@ -92,10 +98,14 @@ class TargetImageFaceAnalysisTests(unittest.TestCase):
             many_faces=None,
         )
 
-        face_analyser.get_unique_faces_from_target_image()
+        output = StringIO()
+        with redirect_stdout(output):
+            result = face_analyser.get_unique_faces_from_target_image()
 
+        self.assertEqual(result, [])
         self.assertEqual(fake_globals.source_target_map, [])
         self.assertEqual(len(calls["get_many_faces"]), 1)
+        self.assertIn("No faces detected in target image: target.png", output.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Exit `get_unique_faces_from_target_image()` early when `cv2.imread()` cannot read the target image.
- Treat `get_many_faces()` returning `None` as no detected faces instead of iterating over it.
- Add focused lightweight tests for unreadable target images and `None` face detections.

## Validation
- `python3 -m unittest tests/test_face_analyser_target_image.py`
- `python3 -m py_compile modules/face_analyser.py tests/test_face_analyser_target_image.py`
- `git diff --check`
- `bash /Users/ming/.openclaw/skills/code-change-delivery-contract/scripts/scan_delivery_blockers.sh`

## Summary by Sourcery

Handle unreadable target images and missing face detections more safely in face analysis.

Bug Fixes:
- Stop processing when the target image cannot be read, preventing downstream face analysis errors.
- Treat a None result from face detection as no faces found to avoid iterating over a non-iterable value.

Tests:
- Add unit tests covering unreadable target images and None face detection results for target image analysis.