### PR TITLE
Guard ONNX enhancer against malformed landmarks

### DIFF
--- a/modules/processors/frame/_onnx_enhancer.py
+++ b/modules/processors/frame/_onnx_enhancer.py
@@ -168,7 +168,14 @@ def _get_face_affine(face: Any, input_size: int):
     if hasattr(face, "kps") and face.kps is not None:
         landmarks = face.kps.astype(np.float32)
     elif hasattr(face, "landmark_2d_106") and face.landmark_2d_106 is not None:
-        lm106 = face.landmark_2d_106
+        try:
+            lm106 = np.asarray(face.landmark_2d_106, dtype=np.float32)
+        except (TypeError, ValueError):
+            return None, None
+
+        if lm106.ndim != 2 or lm106.shape[0] <= 88 or lm106.shape[1] < 2:
+            return None, None
+
         landmarks = np.array([
             lm106[38],  # left eye
             lm106[88],  # right eye

--- a/modules/processors/frame/_onnx_enhancer.py
+++ b/modules/processors/frame/_onnx_enhancer.py
@@ -20,6 +20,13 @@ IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm6
 # Limit concurrent ONNX calls to avoid VRAM exhaustion on multi-face frames
 THREAD_SEMAPHORE = threading.Semaphore(min(max(1, (os.cpu_count() or 1)), 8))
 
+# InsightFace's 106-point landmark layout indexes used by the GPEN alignment
+# fallback. Keep this path as an allow-list for that exact layout instead of
+# accepting arbitrary model-specific landmark arrays and trying to reject known
+# bad shapes after the fact.
+LANDMARK_2D_106_POINT_COUNT = 106
+LANDMARK_2D_106_AFFINE_INDICES = (38, 88, 86, 52, 61)
+
 
 def build_provider_config(providers=None):
     """Wrap raw provider name strings with optimised CUDA / CoreML options.
@@ -173,15 +180,11 @@ def _get_face_affine(face: Any, input_size: int):
         except (TypeError, ValueError):
             return None, None
 
-        if lm106.ndim != 2 or lm106.shape[0] <= 88 or lm106.shape[1] < 2:
+        if lm106.ndim != 2 or lm106.shape[0] != LANDMARK_2D_106_POINT_COUNT or lm106.shape[1] < 2:
             return None, None
 
         landmarks = np.array([
-            lm106[38],  # left eye
-            lm106[88],  # right eye
-            lm106[86],  # nose tip
-            lm106[52],  # left mouth
-            lm106[61],  # right mouth
+            lm106[index] for index in LANDMARK_2D_106_AFFINE_INDICES
         ], dtype=np.float32)
 
     if landmarks is None or len(landmarks) < 5:

--- a/tests/test_onnx_enhancer_affine.py
+++ b/tests/test_onnx_enhancer_affine.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_onnx_enhancer_module():
+    fake_numpy = types.ModuleType("numpy")
+
+    class FakeArray:
+        def __init__(self, value):
+            self.value = value
+            self.ndim, self.shape = self._shape(value)
+
+        @staticmethod
+        def _shape(value):
+            if isinstance(value, list):
+                if value and isinstance(value[0], list):
+                    return 2, (len(value), len(value[0]))
+                return 1, (len(value),)
+            return 0, ()
+
+        def __mul__(self, _other):
+            return self
+
+    def fake_array(value, dtype=None):
+        return FakeArray(value)
+
+    def fake_asarray(value, dtype=None):
+        if not isinstance(value, list):
+            raise TypeError("only lists are supported by this test fake")
+        return FakeArray(value)
+
+    fake_numpy.ndarray = FakeArray
+    fake_numpy.float32 = "float32"
+    fake_numpy.uint8 = int
+    fake_numpy.array = fake_array
+    fake_numpy.asarray = fake_asarray
+    fake_numpy.fromfile = lambda *args, **kwargs: b""
+
+    fake_cv2 = types.ModuleType("cv2")
+    fake_cv2.IMREAD_COLOR = 1
+    fake_cv2.LMEDS = 4
+    fake_cv2.imdecode = lambda *args, **kwargs: None
+    fake_cv2.imencode = lambda *args, **kwargs: (
+        True,
+        types.SimpleNamespace(tofile=lambda *_args, **_kwargs: None),
+    )
+    fake_cv2.estimateAffinePartial2D = mock.Mock(
+        side_effect=AssertionError("malformed landmarks should not reach cv2"),
+    )
+    fake_cv2.invertAffineTransform = mock.Mock()
+
+    fake_onnxruntime = types.ModuleType("onnxruntime")
+    fake_onnxruntime.InferenceSession = object
+    fake_onnxruntime.SessionOptions = lambda: types.SimpleNamespace(
+        graph_optimization_level=None,
+    )
+    fake_onnxruntime.GraphOptimizationLevel = types.SimpleNamespace(
+        ORT_ENABLE_ALL="ORT_ENABLE_ALL",
+    )
+    fake_onnxruntime.OrtValue = types.SimpleNamespace(
+        ortvalue_from_numpy=lambda *args, **kwargs: object(),
+    )
+
+    fake_globals = types.ModuleType("modules.globals")
+    fake_globals.execution_providers = []
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "cv2": fake_cv2,
+            "numpy": fake_numpy,
+            "onnxruntime": fake_onnxruntime,
+            "modules.globals": fake_globals,
+        },
+        clear=False,
+    ):
+        sys.modules.pop("modules.processors.frame._onnx_enhancer", None)
+        return importlib.import_module("modules.processors.frame._onnx_enhancer")
+
+
+class GetFaceAffineLandmarkTests(unittest.TestCase):
+    @staticmethod
+    def _face_with_landmarks(landmarks):
+        return types.SimpleNamespace(kps=None, landmark_2d_106=landmarks)
+
+    def test_short_landmark_106_returns_empty_transform(self) -> None:
+        onnx_enhancer = _load_onnx_enhancer_module()
+
+        transform, inverse = onnx_enhancer._get_face_affine(
+            self._face_with_landmarks([[0, 0]] * 88),
+            512,
+        )
+
+        self.assertIsNone(transform)
+        self.assertIsNone(inverse)
+
+    def test_malformed_landmark_106_returns_empty_transform(self) -> None:
+        onnx_enhancer = _load_onnx_enhancer_module()
+
+        transform, inverse = onnx_enhancer._get_face_affine(
+            self._face_with_landmarks([0] * 106),
+            512,
+        )
+
+        self.assertIsNone(transform)
+        self.assertIsNone(inverse)
+
+    def test_unconvertible_landmark_106_returns_empty_transform(self) -> None:
+        onnx_enhancer = _load_onnx_enhancer_module()
+
+        transform, inverse = onnx_enhancer._get_face_affine(
+            self._face_with_landmarks(object()),
+            512,
+        )
+
+        self.assertIsNone(transform)
+        self.assertIsNone(inverse)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_onnx_enhancer_affine.py
+++ b/tests/test_onnx_enhancer_affine.py
@@ -121,6 +121,17 @@ class GetFaceAffineLandmarkTests(unittest.TestCase):
         self.assertIsNone(transform)
         self.assertIsNone(inverse)
 
+    def test_rejects_non_106_point_landmark_layout(self) -> None:
+        onnx_enhancer = _load_onnx_enhancer_module()
+
+        transform, inverse = onnx_enhancer._get_face_affine(
+            self._face_with_landmarks([[0, 0]] * 107),
+            512,
+        )
+
+        self.assertIsNone(transform)
+        self.assertIsNone(inverse)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- convert the 106-point landmark fallback to a checked float array before indexing
- return an empty transform for missing, short, or malformed landmark data
- add lightweight tests for short, malformed, and unconvertible landmark inputs

## Tests
- python3 -m unittest tests/test_onnx_enhancer_affine.py
- python3 -m py_compile modules/processors/frame/_onnx_enhancer.py tests/test_onnx_enhancer_affine.py
- git diff --check

## Summary by Sourcery

Guard ONNX face affine computation against malformed 106-point landmark inputs and add tests to ensure invalid data returns empty transforms instead of reaching downstream processing.

Bug Fixes:
- Validate and safely convert 106-point landmark data to a float array, returning empty transforms for missing, short, or malformed inputs instead of attempting to index or process them.

Tests:
- Add unit tests covering short, malformed, and unconvertible 106-point landmark inputs to confirm they yield empty transforms and do not invoke OpenCV affine estimation.