### PR TITLE
Guard lower mouth mask against invalid frames

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 import cv2
 import insightface
 from insightface.utils import face_align
@@ -38,6 +38,8 @@ DETECTION_INTERVAL = 0.033  # ~30 FPS detection rate for live mode
 FRAME_SKIP_COUNTER = 0
 ADAPTIVE_QUALITY = True
 # --- END: Mac M1-M5 Optimizations ---
+
+EMPTY_MOUTH_BOX = (0, 0, 0, 0)
 
 abs_dir = os.path.dirname(os.path.abspath(__file__))
 models_dir = os.path.join(
@@ -791,18 +793,20 @@ def process_video(source_path: str, temp_frame_paths: List[str]) -> None:
 # MASKING FUNCTIONS (Mostly unchanged, added safety checks and minor improvements)
 # ==========================
 
+def _empty_lower_mouth_mask(mask_shape: Tuple[int, int]) -> Tuple[np.ndarray, Optional[np.ndarray], Tuple[int, int, int, int], Optional[np.ndarray]]:
+    return np.zeros(mask_shape, dtype=np.uint8), None, EMPTY_MOUTH_BOX, None
+
+
 def create_lower_mouth_mask(
     face: Face, frame: Frame
-) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
-    mouth_cutout = None
-    lower_lip_polygon = None # Initialize
-    mouth_box = (0,0,0,0) # Initialize
+) -> Tuple[np.ndarray, Optional[np.ndarray], Tuple[int, int, int, int], Optional[np.ndarray]]:
+    mask_shape = (0, 0)
+    if frame is not None and hasattr(frame, "shape") and len(frame.shape) >= 2:
+        mask_shape = frame.shape[:2]
+    mask, mouth_cutout, mouth_box, lower_lip_polygon = _empty_lower_mouth_mask(mask_shape)
 
     if frame is None or not hasattr(frame, "shape") or len(frame.shape) < 2:
-        mask = np.zeros((0, 0), dtype=np.uint8)
         return mask, mouth_cutout, mouth_box, lower_lip_polygon
-
-    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
 
     # Validate face and landmarks
     if face is None or not hasattr(face, 'landmark_2d_106'):

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -794,10 +794,15 @@ def process_video(source_path: str, temp_frame_paths: List[str]) -> None:
 def create_lower_mouth_mask(
     face: Face, frame: Frame
 ) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
-    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
     mouth_cutout = None
     lower_lip_polygon = None # Initialize
     mouth_box = (0,0,0,0) # Initialize
+
+    if frame is None or not hasattr(frame, "shape") or len(frame.shape) < 2:
+        mask = np.zeros((0, 0), dtype=np.uint8)
+        return mask, mouth_cutout, mouth_box, lower_lip_polygon
+
+    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
 
     # Validate face and landmarks
     if face is None or not hasattr(face, 'landmark_2d_106'):

--- a/tests/test_face_swapper_mask.py
+++ b/tests/test_face_swapper_mask.py
@@ -35,6 +35,10 @@ def _load_face_swapper_module():
         lambda *args, **kwargs: (True, types.SimpleNamespace(tofile=lambda *_: None)),
     )
     fake_insightface = types.ModuleType("insightface")
+    fake_insightface_utils = types.ModuleType("insightface.utils")
+    fake_insightface_utils.face_align = types.SimpleNamespace(
+        norm_crop2=lambda *args, **kwargs: (None, None),
+    )
 
     fake_globals = types.ModuleType("modules.globals")
     fake_globals.execution_providers = []
@@ -75,6 +79,7 @@ def _load_face_swapper_module():
         {
             "cv2": fake_cv2,
             "insightface": fake_insightface,
+            "insightface.utils": fake_insightface_utils,
             "numpy": fake_numpy,
             "modules.globals": fake_globals,
             "modules.processors.frame.core": fake_core,
@@ -115,6 +120,37 @@ class CreateFaceMaskTests(unittest.TestCase):
         face_swapper = _load_face_swapper_module()
         one_dimensional_frame = types.SimpleNamespace(shape=(10,))
         self.assert_empty_mask(face_swapper, one_dimensional_frame)
+
+
+class CreateLowerMouthMaskTests(unittest.TestCase):
+    @staticmethod
+    def _dummy_face():
+        class DummyFace:
+            landmark_2d_106 = []
+
+        return DummyFace()
+
+    def assert_empty_mouth_mask(self, face_swapper, frame) -> None:
+        result = face_swapper.create_lower_mouth_mask(self._dummy_face(), frame)
+        mask, mouth_cutout, mouth_box, lower_lip_polygon = result
+        self.assertEqual(mask.shape, (0, 0))
+        self.assertEqual(mask.dtype, face_swapper.np.uint8)
+        self.assertIsNone(mouth_cutout)
+        self.assertEqual(mouth_box, (0, 0, 0, 0))
+        self.assertIsNone(lower_lip_polygon)
+
+    def test_create_lower_mouth_mask_returns_defaults_when_frame_is_none(self) -> None:
+        face_swapper = _load_face_swapper_module()
+        self.assert_empty_mouth_mask(face_swapper, None)
+
+    def test_create_lower_mouth_mask_returns_defaults_when_frame_has_no_shape(self) -> None:
+        face_swapper = _load_face_swapper_module()
+        self.assert_empty_mouth_mask(face_swapper, 123)
+
+    def test_create_lower_mouth_mask_returns_defaults_when_frame_is_1d(self) -> None:
+        face_swapper = _load_face_swapper_module()
+        one_dimensional_frame = types.SimpleNamespace(shape=(10,))
+        self.assert_empty_mouth_mask(face_swapper, one_dimensional_frame)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- validate frame input before reading frame.shape in create_lower_mouth_mask
- return the existing empty mask/default mouth metadata for None, missing-shape, and 1D frames
- extend the lightweight face swapper mask tests, including the import stub needed for insightface.utils.face_align

## Tests
- python3 -m unittest tests/test_face_swapper_mask.py
- python3 -m py_compile modules/processors/frame/face_swapper.py tests/test_face_swapper_mask.py
- git diff --check

## Summary by Sourcery

Guard lower mouth mask creation against invalid frame inputs and extend tests accordingly.

Bug Fixes:
- Prevent create_lower_mouth_mask from accessing frame.shape on None, non-array, or 1D frame inputs by returning the default empty mask and mouth metadata instead.

Tests:
- Extend lightweight face swapper mask tests to cover lower mouth mask behavior for None, missing-shape, and 1D frame inputs.
- Stub insightface.utils.face_align in tests to satisfy new or existing imports.