### PR TITLE
Keep GFPGAN on ANE: widen scalar Gather indices for CoreML EP

### DIFF
--- a/modules/onnx_optimize.py
+++ b/modules/onnx_optimize.py
@@ -1,21 +1,32 @@
 """ONNX model optimizations for CoreML execution on Apple Silicon.
 
-Two transformations that eliminate CPU↔ANE round-trips:
+Each pass eliminates a different CPU↔ANE round-trip that ORT's CoreML EP
+would otherwise introduce:
 
-1. **Pad(reflect) decomposition** — CoreML doesn't support ``Pad(mode=reflect)``.
-   Models using reflect padding (e.g. inswapper_128) get split into many CoreML
-   subgraphs with CPU fallbacks between each.  We rewrite each ``Pad(reflect)``
-   as equivalent ``Slice`` + ``Concat`` ops that CoreML handles natively.
-   Bit-for-bit identical output.
-
-2. **Shape/Gather constant folding** — Dynamic ``Shape`` → ``Gather`` chains
+1. **Shape/Gather constant folding** — Dynamic ``Shape`` → ``Gather`` chains
    (e.g. for FPN upsample target sizes in RetinaFace) force ops onto CPU even
    when the input dimensions are known at load time.  We run ONNX shape
    inference with the known input size and replace these chains with constants.
    Float32-noise-level differences only (max ~6e-6).
 
-Both transformations are cached on disk with a ``_coreml`` suffix so the
-rewrite cost is paid only once per model.
+2. **Pad(reflect) decomposition** — CoreML doesn't support ``Pad(mode=reflect)``.
+   Models using reflect padding (e.g. inswapper_128) get split into many CoreML
+   subgraphs with CPU fallbacks between each.  We rewrite each ``Pad(reflect)``
+   as equivalent ``Slice`` + ``Concat`` ops that CoreML handles natively.
+   Bit-for-bit identical output. (Fixed upstream in microsoft/onnxruntime#28073.)
+
+3. **Split → Slice decomposition** — CoreML's EP doesn't support the ONNX
+   ``Split`` op, causing partition boundaries in models with channel-wise
+   splits (e.g. GFPGAN's SFT modulation). Each 2-way Split becomes two Slices.
+
+4. **Scalar Gather widening** — ORT's CoreML EP rejects ``Gather`` nodes with
+   rank-0 (scalar) indices. StyleGAN-derived models (GFPGAN) slice per-layer
+   style codes using exactly this pattern. We widen each scalar index to
+   ``[1]`` and squeeze the added axis on the Gather output.
+   (Filed upstream as microsoft/onnxruntime#28180.)
+
+All passes are cached on disk with a ``_coreml`` suffix so the rewrite cost
+is paid only once per model.
 """
 
 import os
@@ -63,6 +74,12 @@ def optimize_for_coreml(model_path: str, input_shape: tuple = None) -> str:
         changed = True
 
     if _decompose_split(model):
+        changed = True
+
+    # TODO: drop this pass once microsoft/onnxruntime#28180 ships. The CoreML
+    # Gather op builder rejects rank-0 (scalar) indices; we widen them to [1]
+    # + Squeeze so StyleGAN-family models (GFPGAN) stay on ANE.
+    if _rewrite_scalar_gather(model):
         changed = True
 
     if not changed:
@@ -400,6 +417,111 @@ def _decompose_split(model) -> bool:
             new_nodes.extend(replacements[id(node)])
         else:
             new_nodes.append(node)
+
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Pass 4: Widen scalar Gather indices to [1] + Squeeze
+#
+# TEMPORARY: filed upstream as microsoft/onnxruntime#28180. ORT's CoreML EP
+# GatherOpBuilder::IsOpSupportedImpl rejects rank-0 (scalar) indices with
+# `Gather does not support scalar 'indices'`. The builder's own comment
+# describes the workaround (promote to [1], squeeze the added axis) but
+# doesn't apply it. We do the same thing at the ONNX level so StyleGAN-
+# family models (GFPGAN is the hot example — 16 per-layer style-code
+# slices) don't split the CoreML subgraph. Once the upstream fix ships
+# and the ORT floor is raised, delete this pass.
+# ---------------------------------------------------------------------------
+
+def _rewrite_scalar_gather(model) -> bool:
+    """Rewrite Gather(data, scalar_idx) as Gather(data, [scalar_idx]) + Squeeze.
+
+    Only touches Gather nodes whose index is a rank-0 int64 constant or
+    initializer; everything else passes through unchanged. The rewrite
+    is semantically identical — indices get an added leading axis, the
+    Squeeze removes it after the gather.
+    """
+    from onnx import numpy_helper, helper, TensorProto
+
+    graph = model.graph
+
+    # Opset 13 moved Squeeze's axes from attribute to input.
+    opset = next(
+        (o.version for o in model.opset_import if o.domain in ("", "ai.onnx")),
+        11,
+    )
+
+    const_values = {}
+    for n in graph.node:
+        if n.op_type == "Constant":
+            for a in n.attribute:
+                if a.name == "value":
+                    const_values[n.output[0]] = a.t
+    init_values = {i.name: i for i in graph.initializer}
+
+    def scalar_int64(name):
+        """Return int value if `name` resolves to a rank-0 int64 constant, else None."""
+        tensor = const_values.get(name) or init_values.get(name)
+        if tensor is None or tensor.data_type != TensorProto.INT64:
+            return None
+        arr = numpy_helper.to_array(tensor)
+        return int(arr) if arr.ndim == 0 else None
+
+    rewrote = 0
+    new_nodes = []
+    for n in graph.node:
+        if n.op_type == "Gather":
+            val = scalar_int64(n.input[1])
+            if val is not None:
+                axis = next((a.i for a in n.attribute if a.name == "axis"), 0)
+                idx_1d_name = f"{n.input[1]}_1d_{rewrote}"
+                idx_const = helper.make_node(
+                    "Constant",
+                    inputs=[],
+                    outputs=[idx_1d_name],
+                    value=helper.make_tensor(idx_1d_name, TensorProto.INT64, [1], [val]),
+                )
+                gather_out = f"{n.output[0]}_pre_squeeze_{rewrote}"
+                new_gather = helper.make_node(
+                    "Gather",
+                    inputs=[n.input[0], idx_1d_name],
+                    outputs=[gather_out],
+                    name=n.name,
+                    axis=axis,
+                )
+                if opset < 13:
+                    squeeze = helper.make_node(
+                        "Squeeze",
+                        inputs=[gather_out],
+                        outputs=[n.output[0]],
+                        name=(n.name or "gather") + "_squeeze",
+                        axes=[axis],
+                    )
+                    new_nodes.extend([idx_const, new_gather, squeeze])
+                else:
+                    axes_name = f"{idx_1d_name}_sq_axes"
+                    axes_const = helper.make_node(
+                        "Constant",
+                        inputs=[],
+                        outputs=[axes_name],
+                        value=helper.make_tensor(axes_name, TensorProto.INT64, [1], [axis]),
+                    )
+                    squeeze = helper.make_node(
+                        "Squeeze",
+                        inputs=[gather_out, axes_name],
+                        outputs=[n.output[0]],
+                        name=(n.name or "gather") + "_squeeze",
+                    )
+                    new_nodes.extend([idx_const, axes_const, new_gather, squeeze])
+                rewrote += 1
+                continue
+        new_nodes.append(n)
+
+    if rewrote == 0:
+        return False
 
     del graph.node[:]
     graph.node.extend(new_nodes)

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -178,17 +178,17 @@ def _paste_back(
     h, w = frame.shape[:2]
     inv_matrix = cv2.invertAffineTransform(affine_matrix)
 
-    # Build or reuse cached feathered mask
+    # Build or reuse cached feathered mask (uint8 — blended via cv2 SIMD ops)
     if _enhancer_cache['mask_size'] != output_size:
-        face_mask = np.ones((output_size, output_size), dtype=np.float32)
+        face_mask_f = np.ones((output_size, output_size), dtype=np.float32)
         border = max(1, int(output_size * 0.05))
         ramp_up = np.linspace(0.0, 1.0, border, dtype=np.float32)
         ramp_down = np.linspace(1.0, 0.0, border, dtype=np.float32)
-        face_mask[:border, :] *= ramp_up[:, None]
-        face_mask[-border:, :] *= ramp_down[:, None]
-        face_mask[:, :border] *= ramp_up[None, :]
-        face_mask[:, -border:] *= ramp_down[None, :]
-        _enhancer_cache['mask'] = face_mask
+        face_mask_f[:border, :] *= ramp_up[:, None]
+        face_mask_f[-border:, :] *= ramp_down[:, None]
+        face_mask_f[:, :border] *= ramp_up[None, :]
+        face_mask_f[:, -border:] *= ramp_down[None, :]
+        _enhancer_cache['mask'] = (face_mask_f * 255.0).astype(np.uint8)
         _enhancer_cache['mask_size'] = output_size
 
     # Compute tight bbox from affine corners (avoids full-frame warpAffine scan)
@@ -220,25 +220,26 @@ def _paste_back(
     )
     inv_mask_crop = cv2.warpAffine(
         _enhancer_cache['mask'], inv_crop, (crop_w, crop_h),
-        borderMode=cv2.BORDER_CONSTANT, borderValue=0.0,
+        borderMode=cv2.BORDER_CONSTANT, borderValue=0,
     )
-    np.clip(inv_mask_crop, 0.0, 1.0, out=inv_mask_crop)
+
+    target_crop = frame[y1p:y2p, x1p:x2p]
 
     if _HAS_TORCH_CUDA:
-        # GPU blend on crop only
-        mask_t = torch.from_numpy(inv_mask_crop).cuda().unsqueeze(2)
+        # Upload uint8 alpha — smaller transfer, scale on device.
+        mask_t = torch.from_numpy(inv_mask_crop).cuda().float().mul_(1.0 / 255.0).unsqueeze(2)
         enhanced_t = torch.from_numpy(inv_restored_crop).float().cuda()
-        target_t = torch.from_numpy(frame[y1p:y2p, x1p:x2p]).float().cuda()
+        target_t = torch.from_numpy(target_crop).float().cuda()
         blended = (mask_t * enhanced_t + (1.0 - mask_t) * target_t
                    ).to(torch.uint8).cpu().numpy()
         frame[y1p:y2p, x1p:x2p] = blended
     else:
-        # CPU blend on crop only
-        mask_3d = inv_mask_crop[:, :, np.newaxis]
-        target_crop = frame[y1p:y2p, x1p:x2p].astype(np.float32)
-        blended = (mask_3d * inv_restored_crop.astype(np.float32)
-                   + (1.0 - mask_3d) * target_crop)
-        frame[y1p:y2p, x1p:x2p] = np.clip(blended, 0, 255).astype(np.uint8)
+        # Fused uint8 blend via cv2 SIMD — ~7× faster than the float32 round-trip.
+        alpha_3c = cv2.merge([inv_mask_crop, inv_mask_crop, inv_mask_crop])
+        inv_alpha = 255 - alpha_3c
+        a_enh = cv2.multiply(inv_restored_crop, alpha_3c, scale=1.0 / 255.0)
+        a_tgt = cv2.multiply(target_crop, inv_alpha, scale=1.0 / 255.0)
+        frame[y1p:y2p, x1p:x2p] = cv2.add(a_enh, a_tgt)
 
     return frame
 

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -178,7 +178,7 @@ def _get_soft_alpha(size: int) -> np.ndarray:
         mask = np.full((size, size), 255, dtype=np.uint8)
         mask = cv2.erode(mask, np.ones((k_erode, k_erode), np.uint8), iterations=1)
         mask = cv2.GaussianBlur(mask, (2 * k_blur + 1, 2 * k_blur + 1), 0)
-        _paste_cache['soft_alpha'] = mask.astype(np.float32) * (1.0 / 255.0)
+        _paste_cache['soft_alpha'] = mask  # uint8 [0, 255] — blended via cv2 SIMD ops
         _paste_cache['alpha_size'] = size
     return _paste_cache['soft_alpha']
 
@@ -323,20 +323,25 @@ def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, 
 
     soft_alpha = _get_soft_alpha(face_h)
     bgr_fake_crop = cv2.warpAffine(bgr_fake, IM_crop, (crop_w, crop_h), borderValue=0.0)
-    alpha_crop = cv2.warpAffine(soft_alpha, IM_crop, (crop_w, crop_h), borderValue=0.0)
+    alpha_crop = cv2.warpAffine(soft_alpha, IM_crop, (crop_w, crop_h), borderValue=0)
+
+    target_crop = target_img[y1p:y2p, x1p:x2p]
 
     if _HAS_TORCH_CUDA:
-        mask_t = torch.from_numpy(alpha_crop).cuda().unsqueeze(2)
+        # Scale alpha to [0, 1] on device — cheaper to upload uint8 than float.
+        mask_t = torch.from_numpy(alpha_crop).cuda().float().mul_(1.0 / 255.0).unsqueeze(2)
         fake_t = torch.from_numpy(bgr_fake_crop).float().cuda()
-        tgt_t = torch.from_numpy(target_img[y1p:y2p, x1p:x2p]).float().cuda()
+        tgt_t = torch.from_numpy(target_crop).float().cuda()
         blended = (mask_t * fake_t + (1.0 - mask_t) * tgt_t).to(torch.uint8).cpu().numpy()
         target_img[y1p:y2p, x1p:x2p] = blended
     else:
-        mask_3d = alpha_crop[:, :, np.newaxis]
-        fake_f = bgr_fake_crop.astype(np.float32)
-        tgt_f = target_img[y1p:y2p, x1p:x2p].astype(np.float32)
-        blended = mask_3d * fake_f + (1.0 - mask_3d) * tgt_f
-        target_img[y1p:y2p, x1p:x2p] = np.clip(blended, 0, 255).astype(np.uint8)
+        # Fused uint8 blend via cv2 SIMD — no float32 round-trip.
+        # Measured ~7-8× faster than the old numpy float32 path on a 1000×1000 crop.
+        alpha_3c = cv2.merge([alpha_crop, alpha_crop, alpha_crop])
+        inv_alpha = 255 - alpha_3c
+        a_fake = cv2.multiply(bgr_fake_crop, alpha_3c, scale=1.0 / 255.0)
+        a_tgt = cv2.multiply(target_crop, inv_alpha, scale=1.0 / 255.0)
+        target_img[y1p:y2p, x1p:x2p] = cv2.add(a_fake, a_tgt)
 
     return target_img
 

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -297,6 +297,10 @@ def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, 
     """
     h, w = target_img.shape[:2]
     face_h, face_w = aimg.shape[:2]
+    # inswapper's aligned-face space is square (128x128). _get_soft_alpha
+    # caches a single NxN template keyed by N, so fail loudly if that ever
+    # stops being true rather than silently mis-warping the alpha mask.
+    assert face_h == face_w, f"Expected square aligned face, got {face_h}x{face_w}"
     IM = cv2.invertAffineTransform(M)
 
     # Bbox in output coords from the affine corners of the aligned-face square.

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -157,8 +157,30 @@ except ImportError:
 
 # Cache for paste-back
 _paste_cache = {
-    'mask_white': None,  # pre-allocated white image
+    'soft_alpha': None,  # feathered alpha mask in aligned-face space
+    'alpha_size': 0,
 }
+
+
+def _get_soft_alpha(size: int) -> np.ndarray:
+    """Feathered alpha template in aligned-face space, cached.
+
+    The legacy paste-back eroded and Gaussian-blurred the warped mask in
+    output coordinates with kernels scaled to the output face size, which
+    made the per-frame cost quartic in face linear size. Doing the same
+    erode+blur once in aligned space and then warping the *soft* mask
+    per-frame gives a visually equivalent feather at O(crop_area) cost —
+    the feather radius scales naturally with the affine transform.
+    """
+    if _paste_cache['alpha_size'] != size:
+        k_erode = max(size // 10, 3)
+        k_blur = max(size // 20, 3)
+        mask = np.full((size, size), 255, dtype=np.uint8)
+        mask = cv2.erode(mask, np.ones((k_erode, k_erode), np.uint8), iterations=1)
+        mask = cv2.GaussianBlur(mask, (2 * k_blur + 1, 2 * k_blur + 1), 0)
+        _paste_cache['soft_alpha'] = mask.astype(np.float32) * (1.0 / 255.0)
+        _paste_cache['alpha_size'] = size
+    return _paste_cache['soft_alpha']
 
 # CUDA graph swap session cache
 _cuda_graph_session = {
@@ -266,112 +288,57 @@ def _cuda_graph_swap_inference(blob: np.ndarray, latent: np.ndarray) -> np.ndarr
 
 
 def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, M: np.ndarray) -> Frame:
-    """GPU-accelerated paste-back that restricts blending to the face bounding box.
+    """Paste bgr_fake back onto target_img via the inverse affine of M.
 
-    Same visual output as insightface's built-in paste_back, but:
-    - Skips dead fake_diff code (computed but unused in insightface)
-    - Runs erosion, blur, and blend on the face bbox instead of the full frame
-    - Uses torch CUDA for warpAffine + blend when available
-    - Writes directly into target_img to avoid full-frame copy
+    Restricts work to the face bbox in output coordinates and warps a
+    precomputed feathered alpha template per-frame instead of running a
+    size-scaled erode+blur on the warped mask. Cost is O(crop_area) regardless
+    of how much of the frame the face occupies.
     """
     h, w = target_img.shape[:2]
     face_h, face_w = aimg.shape[:2]
     IM = cv2.invertAffineTransform(M)
 
-    # Reuse pre-allocated white mask
-    if _paste_cache['mask_white'] is None or _paste_cache['mask_white'].shape != (face_h, face_w):
-        _paste_cache['mask_white'] = np.full((face_h, face_w), 255, dtype=np.float32)
+    # Bbox in output coords from the affine corners of the aligned-face square.
+    corners = np.array(
+        [[0, 0], [face_w, 0], [face_w, face_h], [0, face_h]], dtype=np.float32
+    )
+    transformed = (IM[:, :2] @ corners.T).T + IM[:, 2]
+    x1 = int(np.floor(transformed[:, 0].min()))
+    x2 = int(np.ceil(transformed[:, 0].max()))
+    y1 = int(np.floor(transformed[:, 1].min()))
+    y2 = int(np.ceil(transformed[:, 1].max()))
+    if x1 >= x2 or y1 >= y2:
+        return target_img
+
+    # Small interpolation margin only — the feather is baked into the template.
+    pad = 2
+    y1p, y2p = max(0, y1 - pad), min(h, y2 + pad + 1)
+    x1p, x2p = max(0, x1 - pad), min(w, x2 + pad + 1)
+
+    IM_crop = IM.copy()
+    IM_crop[0, 2] -= x1p
+    IM_crop[1, 2] -= y1p
+    crop_w, crop_h = x2p - x1p, y2p - y1p
+
+    soft_alpha = _get_soft_alpha(face_h)
+    bgr_fake_crop = cv2.warpAffine(bgr_fake, IM_crop, (crop_w, crop_h), borderValue=0.0)
+    alpha_crop = cv2.warpAffine(soft_alpha, IM_crop, (crop_w, crop_h), borderValue=0.0)
 
     if _HAS_TORCH_CUDA:
-        # GPU path: compute bbox from affine matrix (avoids warpAffine + scan on white mask)
-        corners = np.array([[0, 0], [face_w, 0], [face_w, face_h], [0, face_h]], dtype=np.float32)
-        transformed = (IM[:, :2] @ corners.T).T + IM[:, 2]
-        x1 = int(np.floor(transformed[:, 0].min()))
-        x2 = int(np.ceil(transformed[:, 0].max()))
-        y1 = int(np.floor(transformed[:, 1].min()))
-        y2 = int(np.ceil(transformed[:, 1].max()))
-        if x1 >= x2 or y1 >= y2:
-            return target_img
-
-        mask_h = y2 - y1
-        mask_w = x2 - x1
-        mask_size = int(np.sqrt(mask_h * mask_w))
-        k_erode = max(mask_size // 10, 10)
-        k_blur = max(mask_size // 20, 5)
-
-        pad = k_erode + k_blur + 2
-        y1p, y2p = max(0, y1 - pad), min(h, y2 + pad + 1)
-        x1p, x2p = max(0, x1 - pad), min(w, x2 + pad + 1)
-
-        # Warp face and mask into crop region only (CPU — fast on small image)
-        IM_crop = IM.copy()
-        IM_crop[0, 2] -= x1p
-        IM_crop[1, 2] -= y1p
-        crop_w, crop_h = x2p - x1p, y2p - y1p
-
-        bgr_fake_crop = cv2.warpAffine(bgr_fake, IM_crop, (crop_w, crop_h), borderValue=0.0)
-        mask_crop = cv2.warpAffine(_paste_cache['mask_white'], IM_crop, (crop_w, crop_h), borderValue=0.0)
-
-        # All mask processing + blend on GPU (no CPU roundtrips)
-        mask_t = torch.from_numpy(mask_crop).cuda()
-        mask_t = torch.where(mask_t > 20, 255.0, 0.0)
-        orig_h, orig_w = mask_t.shape
-
-        # Erode via negative max_pool (equivalent to min_pool)
-        m4 = mask_t.unsqueeze(0).unsqueeze(0)
-        m4 = -torch.nn.functional.max_pool2d(-m4, kernel_size=k_erode, stride=1, padding=k_erode // 2)
-
-        # Gaussian blur approximation via avg_pool
-        bk = 2 * k_blur + 1
-        m4 = torch.nn.functional.avg_pool2d(m4, kernel_size=bk, stride=1, padding=bk // 2)
-
-        # Fix any padding-induced size mismatch
-        m4 = m4[:, :, :orig_h, :orig_w]
-
-        mask_3d = (m4.squeeze() * (1.0 / 255.0)).unsqueeze(2)
+        mask_t = torch.from_numpy(alpha_crop).cuda().unsqueeze(2)
         fake_t = torch.from_numpy(bgr_fake_crop).float().cuda()
         tgt_t = torch.from_numpy(target_img[y1p:y2p, x1p:x2p]).float().cuda()
-        blended = (mask_3d * fake_t + (1.0 - mask_3d) * tgt_t).to(torch.uint8).cpu().numpy()
-
+        blended = (mask_t * fake_t + (1.0 - mask_t) * tgt_t).to(torch.uint8).cpu().numpy()
         target_img[y1p:y2p, x1p:x2p] = blended
-        return target_img
     else:
-        # CPU fallback
-        bgr_fake_full = cv2.warpAffine(bgr_fake, IM, (w, h), borderValue=0.0)
-        img_white_full = cv2.warpAffine(_paste_cache['mask_white'], IM, (w, h), borderValue=0.0)
-
-        rows = np.any(img_white_full > 20, axis=1)
-        cols = np.any(img_white_full > 20, axis=0)
-        row_idx = np.where(rows)[0]
-        col_idx = np.where(cols)[0]
-        if len(row_idx) == 0 or len(col_idx) == 0:
-            return target_img
-        y1, y2 = row_idx[0], row_idx[-1]
-        x1, x2 = col_idx[0], col_idx[-1]
-
-        mask_h = y2 - y1
-        mask_w = x2 - x1
-        mask_size = int(np.sqrt(mask_h * mask_w))
-        k_erode = max(mask_size // 10, 10)
-        k_blur = max(mask_size // 20, 5)
-
-        pad = k_erode + k_blur + 2
-        y1p, y2p = max(0, y1 - pad), min(h, y2 + pad + 1)
-        x1p, x2p = max(0, x1 - pad), min(w, x2 + pad + 1)
-
-        mask_crop = img_white_full[y1p:y2p, x1p:x2p]
-        mask_crop[mask_crop > 20] = 255
-        mask_crop = cv2.erode(mask_crop, np.ones((k_erode, k_erode), np.uint8), iterations=1)
-        mask_crop = cv2.GaussianBlur(mask_crop, (2*k_blur+1, 2*k_blur+1), 0)
-        mask_crop *= (1.0 / 255.0)
-
-        mask_3d = mask_crop[:, :, np.newaxis]
-        fake_crop = bgr_fake_full[y1p:y2p, x1p:x2p].astype(np.float32)
-        target_crop = target_img[y1p:y2p, x1p:x2p].astype(np.float32)
-        blended = mask_3d * fake_crop + (1.0 - mask_3d) * target_crop
-        # Write in-place, consistent with the GPU path
+        mask_3d = alpha_crop[:, :, np.newaxis]
+        fake_f = bgr_fake_crop.astype(np.float32)
+        tgt_f = target_img[y1p:y2p, x1p:x2p].astype(np.float32)
+        blended = mask_3d * fake_f + (1.0 - mask_3d) * tgt_f
         target_img[y1p:y2p, x1p:x2p] = np.clip(blended, 0, 255).astype(np.uint8)
-        return target_img
+
+    return target_img
 
 
 def swap_face(source_face: Face, target_face: Face, temp_frame: Frame) -> Frame:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1220,11 +1220,9 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
                 2,
             )
 
-        # BGR→RGB in the processing thread so the display thread gets
-        # a contiguous RGB array (faster PIL.fromarray).
-        temp_frame = cv2.cvtColor(temp_frame, cv2.COLOR_BGR2RGB)
-
-        # Put processed frame into output queue, dropping old frames if full
+        # Queue the processed frame as BGR; the display thread resizes to the
+        # preview window first and then runs cvtColor on the (much smaller)
+        # buffer — cheaper than converting the full 1080p frame here.
         try:
             processed_queue.put_nowait(temp_frame)
         except queue.Full:
@@ -1294,15 +1292,17 @@ def create_webcam_preview(camera_index: int):
             return
 
         try:
-            rgb_frame = processed_queue.get_nowait()
+            bgr_frame = processed_queue.get_nowait()
         except queue.Empty:
             ROOT.after(poll_ms, _display_next_frame)
             return
 
-        # Frame is already RGB from processing thread; resize to preview window
-        rgb_frame = fit_image_to_size(
-            rgb_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
+        # Resize the full-resolution BGR frame to the preview window first,
+        # then convert colour on the smaller buffer.
+        bgr_frame = fit_image_to_size(
+            bgr_frame, PREVIEW.winfo_width(), PREVIEW.winfo_height()
         )
+        rgb_frame = cv2.cvtColor(bgr_frame, cv2.COLOR_BGR2RGB)
         image = Image.fromarray(rgb_frame)
         image = ctk.CTkImage(image, size=image.size)
         preview_label.configure(image=image)


### PR DESCRIPTION
## Summary

ONNX Runtime's CoreML EP rejects `Gather` nodes with rank-0 (scalar) index tensors. StyleGAN-derived models hit this pattern heavily — GFPGAN's 1024-variant has 16 such Gathers, one per style-code slice — and the resulting CPU fallbacks split the CoreML subgraph into two partitions with boundary crossings on every inference.

Added a load-time ONNX rewrite (`_rewrite_scalar_gather`) to `modules/onnx_optimize.py` alongside the existing passes. It promotes each scalar index to `[1]` and squeezes the added axis on the Gather output — semantically identical but CoreML-compatible.

## Stacking note

**Stacked on top of #1776** (paste-back optimisation). GitHub doesn't let a cross-fork PR target a branch that isn't in the upstream, so until #1776 merges this PR will show its four commits *plus* this one. Once #1776 lands on `main`, this diff will shrink to the single `modules/onnx_optimize.py` change. Please merge #1776 first.

## Result (Apple M-series, onnxruntime-silicon 1.24.4, CoreML MLProgram + MLComputeUnits=ALL, 512² input)

| | CoreML partitions | CPU-fallback nodes | inference |
|---|---|---|---|
| before | 2 | 16 | 86.8 ms |
| after  | **1** | **0** | **80.6 ms** |

GFPGAN now runs as a single CoreML partition on the Neural Engine with zero CPU boundary crossings. ~7% faster in absolute terms; the bigger payoff is architectural (no more CPU↔ANE ping-pong).

## Upstream context

Filed as [microsoft/onnxruntime#28180](https://github.com/microsoft/onnxruntime/issues/28180). The existing code comment in `gather_op_builder.cc` already describes this exact workaround, it just isn't applied. Once the upstream fix ships and the ORT floor is raised, `_rewrite_scalar_gather` can be deleted (the TODO in the source points at the issue).

## Root cause detail

`onnxruntime/core/providers/coreml/builders/impl/gather_op_builder.cc`:
```cpp
// Don't allow scalar 'indices' input.
// We convert scalar inputs to tensors with shape [1] before providing them to CoreML.
// This modification changes the shape of the Gather output.
if (indices_shape.empty()) {
    LOGS(logger, VERBOSE) << "Gather does not support scalar 'indices'";
    return false;
}
```

Minimal reproducer in the upstream issue: `Gather(X, scalar_idx)` falls to CPU, `Gather(X, [scalar_idx]) + Squeeze` stays on CoreML.

## Test plan

- [ ] Live webcam preview on Apple Silicon (CoreML) with face enhancer enabled: verify steady FPS and no visual regression on the enhanced face.
- [ ] Offline video with `--frame-processor face_enhancer`: verify output is pixel-identical to pre-change (the rewrite is semantically identical — indices get an added axis, squeeze removes it).
- [ ] Non-Apple-Silicon: module short-circuits on `IS_APPLE_SILICON`, so no effect.
- [ ] Models without scalar Gathers (inswapper_128, retinaface det_10g): pass short-circuits when `rewrote == 0`, so no effect.

## Safety

- Pass is a pure graph rewrite (no numeric change).
- Gated by `IS_APPLE_SILICON` via the existing `optimize_for_coreml` entry.
- Short-circuits when there are no scalar-index Gathers (common case).
- Opset-aware: emits the opset-11 `Squeeze(axes=attr)` or opset-13+ `Squeeze(axes=input)` form depending on the model.