### PR TITLE
fix: make detect_fps fall back on ffprobe errors

### DIFF
--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -53,7 +53,16 @@ def detect_fps(target_path: str) -> float:
         target_path,
     ]
     try:
-        output = subprocess.check_output(command, encoding="utf-8").strip().split("/")
+        # Keep shell=False by passing a sequence; target_path is an ffprobe argument,
+        # not command text, so paths containing shell metacharacters are not executed.
+        completed = subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+        output = completed.stdout.strip().split("/")
         numerator, denominator = map(int, output)
         return numerator / denominator
     except (

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -40,23 +40,22 @@ def run_ffmpeg(args: List[str]) -> bool:
 
 
 def detect_fps(target_path: str) -> float:
-    command = [
-        "ffprobe",
-        "-v",
-        "error",
-        "-select_streams",
-        "v:0",
-        "-show_entries",
-        "stream=r_frame_rate",
-        "-of",
-        "default=noprint_wrappers=1:nokey=1",
-        target_path,
-    ]
     try:
-        # Keep shell=False by passing a sequence; target_path is an ffprobe argument,
-        # not command text, so paths containing shell metacharacters are not executed.
+        # Keep shell=False by passing a literal argument vector; target_path is an
+        # ffprobe argument, not command text, so shell metacharacters are inert.
         completed = subprocess.run(
-            command,
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=r_frame_rate",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                target_path,
+            ],
             check=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -52,11 +52,17 @@ def detect_fps(target_path: str) -> float:
         "default=noprint_wrappers=1:nokey=1",
         target_path,
     ]
-    output = subprocess.check_output(command).decode().strip().split("/")
     try:
+        output = subprocess.check_output(command, encoding="utf-8").strip().split("/")
         numerator, denominator = map(int, output)
         return numerator / denominator
-    except Exception:
+    except (
+        subprocess.CalledProcessError,
+        OSError,
+        UnicodeDecodeError,
+        ValueError,
+        ZeroDivisionError,
+    ):
         pass
     return 30.0
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_utilities_module():
+    fake_globals = types.ModuleType("modules.globals")
+    fake_globals.execution_threads = 0
+    fake_globals.log_level = "error"
+    fake_globals.execution_providers = []
+    fake_globals.video_encoder = "libx264"
+    fake_globals.video_quality = 23
+
+    fake_cv2 = types.ModuleType("cv2")
+    fake_cv2.IMREAD_COLOR = 1
+    fake_cv2.imdecode = lambda *args, **kwargs: None
+    fake_cv2.imencode = lambda *args, **kwargs: (True, types.SimpleNamespace(tofile=lambda *_: None))
+
+    fake_numpy = types.ModuleType("numpy")
+    fake_numpy.uint8 = int
+    fake_numpy.fromfile = lambda *args, **kwargs: b""
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "modules.globals": fake_globals,
+            "cv2": fake_cv2,
+            "numpy": fake_numpy,
+        },
+        clear=False,
+    ):
+        sys.modules.pop("modules", None)
+        sys.modules.pop("modules.utilities", None)
+        return importlib.import_module("modules.utilities")
+
+
+class DetectFpsTests(unittest.TestCase):
+    def test_detect_fps_returns_fraction_result(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(
+            utilities.subprocess, "check_output", return_value="30000/1001\n"
+        ):
+            self.assertAlmostEqual(utilities.detect_fps("demo.mp4"), 30000 / 1001)
+
+    def test_detect_fps_falls_back_on_command_failure(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(
+            utilities.subprocess,
+            "check_output",
+            side_effect=utilities.subprocess.CalledProcessError(1, ["ffprobe"]),
+        ):
+            self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
+
+    def test_detect_fps_falls_back_on_malformed_output(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(
+            utilities.subprocess, "check_output", return_value="not-a-fraction"
+        ):
+            self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
+
+    def test_detect_fps_falls_back_on_zero_denominator(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(utilities.subprocess, "check_output", return_value="30/0"):
+            self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -43,7 +43,7 @@ class DetectFpsTests(unittest.TestCase):
         utilities = _load_utilities_module()
 
         with mock.patch.object(
-            utilities.subprocess, "check_output", return_value="30000/1001\n"
+            utilities.subprocess, "run", return_value=types.SimpleNamespace(stdout="30000/1001\n")
         ):
             self.assertAlmostEqual(utilities.detect_fps("demo.mp4"), 30000 / 1001)
 
@@ -52,7 +52,7 @@ class DetectFpsTests(unittest.TestCase):
 
         with mock.patch.object(
             utilities.subprocess,
-            "check_output",
+            "run",
             side_effect=utilities.subprocess.CalledProcessError(1, ["ffprobe"]),
         ):
             self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
@@ -61,14 +61,14 @@ class DetectFpsTests(unittest.TestCase):
         utilities = _load_utilities_module()
 
         with mock.patch.object(
-            utilities.subprocess, "check_output", return_value="not-a-fraction"
+            utilities.subprocess, "run", return_value=types.SimpleNamespace(stdout="not-a-fraction")
         ):
             self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
 
     def test_detect_fps_falls_back_on_zero_denominator(self) -> None:
         utilities = _load_utilities_module()
 
-        with mock.patch.object(utilities.subprocess, "check_output", return_value="30/0"):
+        with mock.patch.object(utilities.subprocess, "run", return_value=types.SimpleNamespace(stdout="30/0")):
             self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
 
 


### PR DESCRIPTION
## Summary
- make `detect_fps()` fall back to `30.0` when `ffprobe` fails or returns malformed frame-rate output
- use explicit UTF-8 decoding for the `ffprobe` result
- add focused tests for valid output, command failure, malformed output, and zero denominator

## Why
`detect_fps()` currently calls `ffprobe` outside the protected parsing block, so subprocess failures can still bubble up and break video processing even though the function already has a `30.0` fallback.

This keeps the existing fallback behavior but applies it to command failures and malformed metadata as well.

## Testing
- `python3 -m unittest tests.test_utilities`

## Summary by Sourcery

Harden video frame rate detection to handle ffprobe failures and malformed metadata by falling back consistently to a default FPS value.

Bug Fixes:
- Ensure detect_fps falls back to a default FPS when ffprobe fails, returns malformed output, or produces an invalid fraction such as a zero denominator.

Enhancements:
- Decode ffprobe output explicitly as UTF-8 before parsing the frame rate.

Tests:
- Add unit tests covering normal fraction parsing, ffprobe command failures, malformed ffprobe output, and zero-denominator frame rate values.