### PR TITLE
fix: guard face masking bad inputs

### DIFF
--- a/modules/processors/frame/face_masking.py
+++ b/modules/processors/frame/face_masking.py
@@ -4,6 +4,22 @@ from modules.typing import Face, Frame
 import modules.globals
 from modules.gpu_processing import gpu_gaussian_blur, gpu_resize, gpu_cvt_color
 
+
+def is_valid_frame(frame: Frame) -> bool:
+    return frame is not None and hasattr(frame, "shape") and len(frame.shape) >= 2
+
+
+def create_empty_mask(frame: Frame) -> np.ndarray:
+    if not is_valid_frame(frame):
+        return np.zeros((0, 0), dtype=np.uint8)
+    return np.zeros(frame.shape[:2], dtype=np.uint8)
+
+
+def has_landmarks(face: Face, min_count: int = 106) -> bool:
+    landmarks = getattr(face, "landmark_2d_106", None)
+    return isinstance(landmarks, np.ndarray) and landmarks.shape[0] >= min_count
+
+
 def apply_color_transfer(source, target):
     """
     Apply color transfer from target to source image using LAB color space.
@@ -33,7 +49,10 @@ def apply_color_transfer(source, target):
     return np.clip(result_bgr * 255.0, 0, 255).astype(np.uint8)
 
 def create_face_mask(face: Face, frame: Frame) -> np.ndarray:
-    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
+    mask = create_empty_mask(frame)
+    if not is_valid_frame(frame) or not has_landmarks(face):
+        return mask
+
     landmarks = face.landmark_2d_106
     if landmarks is not None:
         # Convert landmarks to int32
@@ -75,10 +94,13 @@ def create_face_mask(face: Face, frame: Frame) -> np.ndarray:
 def create_lower_mouth_mask(
     face: Face, frame: Frame
 ) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
-    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
+    mask = create_empty_mask(frame)
     mouth_cutout = None
     lower_lip_polygon = None
     mouth_box = (0,0,0,0)
+
+    if not is_valid_frame(frame) or not has_landmarks(face):
+        return mask, mouth_cutout, mouth_box, lower_lip_polygon
 
     landmarks = face.landmark_2d_106
     if landmarks is not None:
@@ -148,8 +170,14 @@ def create_lower_mouth_mask(
     return mask, mouth_cutout, mouth_box, lower_lip_polygon
 
 def create_eyes_mask(face: Face, frame: Frame) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
-    mask = np.zeros(frame.shape[:2], dtype=np.uint8)
+    mask = create_empty_mask(frame)
     eyes_cutout = None
+    eyes_polygon = None
+    eyes_box = (0, 0, 0, 0)
+
+    if not is_valid_frame(frame) or not has_landmarks(face):
+        return mask, eyes_cutout, eyes_box, eyes_polygon
+
     landmarks = face.landmark_2d_106
     if landmarks is not None:
         # Left eye landmarks (87-96) and right eye landmarks (33-42)
@@ -223,8 +251,9 @@ def create_eyes_mask(face: Face, frame: Frame) -> (np.ndarray, np.ndarray, tuple
         
         # Combine points for both eyes
         eyes_polygon = np.vstack([left_points, right_points])
+        eyes_box = (min_x, min_y, max_x, max_y)
         
-    return mask, eyes_cutout, (min_x, min_y, max_x, max_y), eyes_polygon
+    return mask, eyes_cutout, eyes_box, eyes_polygon
 
 def create_curved_eyebrow(points):
     if len(points) >= 5:

--- a/modules/processors/frame/face_masking.py
+++ b/modules/processors/frame/face_masking.py
@@ -1,5 +1,6 @@
 import cv2
 import numpy as np
+from typing import Optional, Tuple
 from modules.typing import Face, Frame
 import modules.globals
 from modules.gpu_processing import gpu_gaussian_blur, gpu_resize, gpu_cvt_color
@@ -9,15 +10,23 @@ def is_valid_frame(frame: Frame) -> bool:
     return frame is not None and hasattr(frame, "shape") and len(frame.shape) >= 2
 
 
-def create_empty_mask(frame: Frame) -> np.ndarray:
+MaskRegionResult = Tuple[np.ndarray, Optional[np.ndarray], tuple[int, int, int, int], Optional[np.ndarray]]
+
+
+def create_empty_mask_with_validity(frame: Frame) -> Tuple[np.ndarray, bool]:
     if not is_valid_frame(frame):
-        return np.zeros((0, 0), dtype=np.uint8)
-    return np.zeros(frame.shape[:2], dtype=np.uint8)
+        return np.zeros((0, 0), dtype=np.uint8), False
+    return np.zeros(frame.shape[:2], dtype=np.uint8), True
+
+
+def create_empty_mask(frame: Frame) -> np.ndarray:
+    mask, _ = create_empty_mask_with_validity(frame)
+    return mask
 
 
 def has_landmarks(face: Face, min_count: int = 106) -> bool:
     landmarks = getattr(face, "landmark_2d_106", None)
-    return isinstance(landmarks, np.ndarray) and landmarks.shape[0] >= min_count
+    return isinstance(landmarks, np.ndarray) and landmarks.ndim >= 1 and landmarks.shape[0] >= min_count
 
 
 def apply_color_transfer(source, target):
@@ -49,8 +58,8 @@ def apply_color_transfer(source, target):
     return np.clip(result_bgr * 255.0, 0, 255).astype(np.uint8)
 
 def create_face_mask(face: Face, frame: Frame) -> np.ndarray:
-    mask = create_empty_mask(frame)
-    if not is_valid_frame(frame) or not has_landmarks(face):
+    mask, frame_is_valid = create_empty_mask_with_validity(frame)
+    if not frame_is_valid or not has_landmarks(face):
         return mask
 
     landmarks = face.landmark_2d_106
@@ -93,13 +102,13 @@ def create_face_mask(face: Face, frame: Frame) -> np.ndarray:
 
 def create_lower_mouth_mask(
     face: Face, frame: Frame
-) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
-    mask = create_empty_mask(frame)
+) -> MaskRegionResult:
+    mask, frame_is_valid = create_empty_mask_with_validity(frame)
     mouth_cutout = None
     lower_lip_polygon = None
     mouth_box = (0,0,0,0)
 
-    if not is_valid_frame(frame) or not has_landmarks(face):
+    if not frame_is_valid or not has_landmarks(face):
         return mask, mouth_cutout, mouth_box, lower_lip_polygon
 
     landmarks = face.landmark_2d_106
@@ -169,13 +178,13 @@ def create_lower_mouth_mask(
 
     return mask, mouth_cutout, mouth_box, lower_lip_polygon
 
-def create_eyes_mask(face: Face, frame: Frame) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
-    mask = create_empty_mask(frame)
+def create_eyes_mask(face: Face, frame: Frame) -> MaskRegionResult:
+    mask, frame_is_valid = create_empty_mask_with_validity(frame)
     eyes_cutout = None
     eyes_polygon = None
     eyes_box = (0, 0, 0, 0)
 
-    if not is_valid_frame(frame) or not has_landmarks(face):
+    if not frame_is_valid or not has_landmarks(face):
         return mask, eyes_cutout, eyes_box, eyes_polygon
 
     landmarks = face.landmark_2d_106
@@ -314,7 +323,7 @@ def create_curved_eyebrow(points):
         return padded_points
     return points
 
-def create_eyebrows_mask(face: Face, frame: Frame) -> (np.ndarray, np.ndarray, tuple, np.ndarray):
+def create_eyebrows_mask(face: Face, frame: Frame) -> MaskRegionResult:
     mask = np.zeros(frame.shape[:2], dtype=np.uint8)
     eyebrows_cutout = None
     landmarks = face.landmark_2d_106

--- a/tests/test_face_masking_mask.py
+++ b/tests/test_face_masking_mask.py
@@ -37,6 +37,14 @@ class FaceMaskingBadInputTest(unittest.TestCase):
         self.assertEqual(mask.shape, (4, 5))
         self.assertFalse(mask.any())
 
+    def test_create_face_mask_returns_frame_sized_empty_mask_for_scalar_landmarks(self):
+        frame = np.zeros((4, 5, 3), dtype=np.uint8)
+
+        mask = face_masking.create_face_mask(types.SimpleNamespace(landmark_2d_106=np.array(1)), frame)
+
+        self.assertEqual(mask.shape, (4, 5))
+        self.assertFalse(mask.any())
+
     def test_lower_mouth_mask_returns_empty_defaults_for_bad_inputs(self):
         mask, cutout, box, polygon = face_masking.create_lower_mouth_mask(None, None)
 

--- a/tests/test_face_masking_mask.py
+++ b/tests/test_face_masking_mask.py
@@ -1,0 +1,63 @@
+import sys
+import types
+import unittest
+
+import numpy as np
+
+
+common_module = types.ModuleType("insightface.app.common")
+common_module.Face = object
+app_module = types.ModuleType("insightface.app")
+app_module.common = common_module
+insightface_module = types.ModuleType("insightface")
+insightface_module.app = app_module
+sys.modules.setdefault("insightface", insightface_module)
+sys.modules.setdefault("insightface.app", app_module)
+sys.modules.setdefault("insightface.app.common", common_module)
+
+from modules.processors.frame import face_masking
+
+
+class FaceMaskingBadInputTest(unittest.TestCase):
+    def test_create_face_mask_returns_empty_mask_for_invalid_frame(self):
+        face = types.SimpleNamespace(landmark_2d_106=np.zeros((106, 2)))
+
+        self.assertEqual(face_masking.create_face_mask(face, None).shape, (0, 0))
+        self.assertEqual(face_masking.create_face_mask(face, object()).shape, (0, 0))
+        self.assertEqual(
+            face_masking.create_face_mask(face, types.SimpleNamespace(shape=(10,))).shape,
+            (0, 0),
+        )
+
+    def test_create_face_mask_returns_frame_sized_empty_mask_without_landmarks(self):
+        frame = np.zeros((4, 5, 3), dtype=np.uint8)
+
+        mask = face_masking.create_face_mask(types.SimpleNamespace(landmark_2d_106=None), frame)
+
+        self.assertEqual(mask.shape, (4, 5))
+        self.assertFalse(mask.any())
+
+    def test_lower_mouth_mask_returns_empty_defaults_for_bad_inputs(self):
+        mask, cutout, box, polygon = face_masking.create_lower_mouth_mask(None, None)
+
+        self.assertEqual(mask.shape, (0, 0))
+        self.assertIsNone(cutout)
+        self.assertEqual(box, (0, 0, 0, 0))
+        self.assertIsNone(polygon)
+
+    def test_eyes_mask_returns_empty_defaults_for_bad_inputs(self):
+        frame = np.zeros((4, 5, 3), dtype=np.uint8)
+
+        mask, cutout, box, polygon = face_masking.create_eyes_mask(
+            types.SimpleNamespace(landmark_2d_106=None), frame
+        )
+
+        self.assertEqual(mask.shape, (4, 5))
+        self.assertFalse(mask.any())
+        self.assertIsNone(cutout)
+        self.assertEqual(box, (0, 0, 0, 0))
+        self.assertIsNone(polygon)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- guard face masking helpers against invalid frames and missing/invalid landmarks
- return empty masks/default cutouts instead of raising on bad inputs
- add focused unit coverage for invalid frame and missing landmark paths

## Tests
- `python3 -m py_compile modules/processors/frame/face_masking.py tests/test_face_masking_mask.py`
- `python3 -m unittest tests/test_face_masking_mask.py`

## Summary by Sourcery

Guard face masking helpers against invalid frames and missing landmarks so they return empty masks and default outputs instead of raising errors.

Bug Fixes:
- Prevent crashes in face, mouth, and eye masking when called with invalid frames or missing/invalid landmarks by returning empty masks and default values.

Tests:
- Add unit tests covering invalid frame and missing-landmark code paths for face, lower mouth, and eyes mask helpers.