### PR TITLE
fix: no cam detected on Arch Linux, use string path for camera capture instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tf_env/
 *.mp4
 *.mkv
 
+.python-version
 .tmp/
 temp/
 .venv/

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1065,7 +1065,7 @@ def get_available_cameras():
         else:
             # Linux camera detection - test first 10 indices
             for i in range(10):
-                cap = cv2.VideoCapture(i)
+                cap = cv2.VideoCapture(f"/dev/video{i}")
                 if cap.isOpened():
                     camera_indices.append(i)
                     camera_names.append(f"Camera {i}")

--- a/modules/video_capture.py
+++ b/modules/video_capture.py
@@ -57,8 +57,11 @@ class VideoCapturer:
                     except Exception:
                         continue
             else:
-                # Unix-like systems (Linux/Mac) capture method
-                self.cap = cv2.VideoCapture(self.device_index)
+                if platform.system() == "Linux":
+                    self.cap = cv2.VideoCapture(f"/dev/video{self.device_index}")
+                else:
+                    # Fallback to OpenCV auto-detection (macOS)
+                    self.cap = cv2.VideoCapture(self.device_index)
 
             if not self.cap or not self.cap.isOpened():
                 raise RuntimeError("Failed to open camera")


### PR DESCRIPTION
On the latest version of Arch Linux, the camera was no longer being detected at startup, causing the application to fail to list any available capture devices.

The fix passes the device path as a string (e.g. `/dev/video0`) directly, which resolves the issue on Arch Linux while preserving the existing behavior on other platforms (Windows/macOS).

## Summary by Sourcery

Update Linux camera handling to open devices via their /dev/videoN path instead of numeric indices and keep existing behavior for other platforms.

Bug Fixes:
- Ensure cameras are correctly detected and opened on recent Arch Linux systems by passing explicit /dev/videoN paths to OpenCV.

Enhancements:
- Refine platform-specific video capture setup to distinguish Linux device-path usage from macOS auto-detection behavior.