### PR TITLE
fix: guard face analyser invalid frames

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -105,6 +105,12 @@ def _is_dml() -> bool:
     return any("DmlExecutionProvider" in p for p in modules.globals.execution_providers)
 
 
+def _is_valid_frame(frame: Frame) -> bool:
+    """Return whether ``frame`` is safe to pass to InsightFace."""
+    shape = getattr(frame, "shape", None)
+    return shape is not None and len(shape) >= 2 and shape[0] > 0 and shape[1] > 0
+
+
 def _analyse_faces(frame: Frame) -> list:
     """Run face detection, then recognition (and optionally landmark).
 
@@ -112,6 +118,9 @@ def _analyse_faces(frame: Frame) -> list:
     landmark_2d_106 model when only face_swapper is active (saves ~1ms
     per face and avoids an unnecessary ONNX session call).
     """
+    if not _is_valid_frame(frame):
+        return []
+
     fa = get_face_analyser()
 
     bboxes, kpss = fa.det_model.detect(frame, max_num=0, metric="default")

--- a/tests/test_face_analyser_invalid_frame.py
+++ b/tests/test_face_analyser_invalid_frame.py
@@ -1,0 +1,47 @@
+import importlib
+import sys
+import types
+import unittest
+
+import numpy as np
+
+
+class FaceAnalyserInvalidFrameTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        insightface = types.ModuleType("insightface")
+        insightface_app = types.ModuleType("insightface.app")
+        insightface_common = types.ModuleType("insightface.app.common")
+        insightface_common.Face = object
+        insightface_app.common = insightface_common
+        insightface.app = insightface_app
+        sys.modules.setdefault("insightface", insightface)
+        sys.modules.setdefault("insightface.app", insightface_app)
+        sys.modules.setdefault("insightface.app.common", insightface_common)
+
+        cluster_analysis = types.ModuleType("modules.cluster_analysis")
+        cluster_analysis.find_cluster_centroids = lambda *args, **kwargs: []
+        cluster_analysis.find_closest_centroid = lambda *args, **kwargs: None
+        sys.modules.setdefault("modules.cluster_analysis", cluster_analysis)
+
+        cls.face_analyser = importlib.import_module("modules.face_analyser")
+
+    def test_get_one_face_returns_none_for_none_frame(self):
+        self.assertIsNone(self.face_analyser.get_one_face(None))
+
+    def test_get_many_faces_returns_empty_list_for_object_without_shape(self):
+        self.assertEqual(self.face_analyser.get_many_faces(object()), [])
+
+    def test_invalid_1d_frame_does_not_initialize_insightface(self):
+        original = self.face_analyser.get_face_analyser
+        try:
+            self.face_analyser.get_face_analyser = lambda: self.fail("InsightFace should not be initialized")
+
+            self.assertIsNone(self.face_analyser.get_one_face(np.array([1, 2, 3])))
+            self.assertEqual(self.face_analyser.get_many_faces(np.array([1, 2, 3])), [])
+        finally:
+            self.face_analyser.get_face_analyser = original
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- return no detections before calling InsightFace when face analyser receives `None`, objects without `shape`, or frames with fewer than two dimensions
- keep `get_one_face()` returning `None` and `get_many_faces()` returning an empty list for invalid inputs
- add lightweight regression coverage that verifies invalid frames do not initialize InsightFace

## Tests
- `python3 -m unittest tests.test_face_analyser_invalid_frame`
- `git diff --check`

## Summary by Sourcery

Guard face analysis against invalid frames to avoid initializing InsightFace on unsupported inputs while preserving existing return conventions.

Bug Fixes:
- Treat None, objects without a shape attribute, and non-2D/empty frames as having no detections before invoking InsightFace.

Tests:
- Add regression tests ensuring invalid frames return None or empty lists as appropriate and do not initialize InsightFace.