### PR TITLE
Quality: Invalid frame index calculation can seek to -1 or out-of-range frames

### DIFF
--- a/modules/capturer.py
+++ b/modules/capturer.py
@@ -14,8 +14,13 @@ def get_video_frame(video_path: str, frame_number: int = 0) -> Any:
     if modules.globals.color_correction:
         capture.set(cv2.CAP_PROP_CONVERT_RGB, 1)
     
-    frame_total = capture.get(cv2.CAP_PROP_FRAME_COUNT)
-    capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))
+    frame_total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    if frame_total <= 0:
+        capture.release()
+        return None
+
+    target_index = 0 if frame_number <= 1 else min(frame_total - 1, frame_number - 1)
+    capture.set(cv2.CAP_PROP_POS_FRAMES, target_index)
     has_frame, frame = capture.read()
 
     if has_frame and modules.globals.color_correction:


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`get_video_frame()` computes the seek position as `min(frame_total, frame_number - 1)`. With the default `frame_number=0`, this becomes `-1` (invalid frame index). For large requested frame numbers, it can also become `frame_total` (also invalid, since last valid frame is `frame_total - 1`). This causes intermittent failed reads (`has_frame=False`) and breaks callers that expect a valid first frame by default.


**Severity**: `high`
**File**: `modules/capturer.py`

### Solution
Clamp to a valid range explicitly and avoid negative/out-of-bounds indices:
`frame_total = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))`
`if frame_total <= 0:` `    capture.release()` `    return None`
`# keep 1-based API: frame_number=1 -> first frame` `target_index = 0 if frame_number <= 1 else min(frame_total - 1, frame_number - 1)` `capture.set(cv2.CAP_PROP_POS_FRAMES, target_index)`


### Changes
- `modules/capturer.py` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1789

## Summary by Sourcery

Bug Fixes:
- Prevent get_video_frame from seeking to negative or out-of-range frame indices, ensuring the default call returns a valid first frame and large frame requests clamp to the last valid frame.