### PR TITLE
Quality: KMeans cluster count is not bounded by sample count, causing runtime ValueError

### DIFF
--- a/modules/cluster_analysis.py
+++ b/modules/cluster_analysis.py
@@ -5,6 +5,18 @@ from typing import Any
 
 
 def find_cluster_centroids(embeddings, max_k=10) -> Any:
+    n_samples = len(embeddings)
+    if n_samples == 0:
+        raise ValueError("embeddings must not be empty")
+    if max_k < 1:
+        raise ValueError("max_k must be at least 1")
+
+    max_k = min(max_k, n_samples)
+    if max_k == 1:
+        kmeans = KMeans(n_clusters=1, random_state=0)
+        kmeans.fit(embeddings)
+        return kmeans.cluster_centers_
+
     inertia = []
     cluster_centroids = []
     K = range(1, max_k+1)


### PR DESCRIPTION
## ✨ Code Quality

### Problem
`find_cluster_centroids()` iterates `k` from 1..`max_k` unconditionally. If `len(embeddings) < max_k`, `KMeans(n_clusters=k)` will raise `ValueError` when `k` exceeds the number of samples. This is an unhandled crash path on small datasets.


**Severity**: `high`
**File**: `modules/cluster_analysis.py`

### Solution
Bound `k` to the number of samples and handle small/empty input safely:
`n_samples = len(embeddings)` `if n_samples == 0:` `    raise ValueError("embeddings must not be empty")` `max_k = min(max_k, n_samples)`
`if max_k == 1:` `    kmeans = KMeans(n_clusters=1, random_state=0).fit(embeddings)` `    return kmeans.cluster_centers_`
Then run the existing loop with `range(1, max_k + 1)`.

### Changes
- `modules/cluster_analysis.py` (modified)

### Testing
- [x] Existing tests pass
- [x] Manual review completed
- [x] No new warnings/errors introduced

---


---

<details>
<summary>🤖 About this PR</summary>

This pull request was generated by [ContribAI](https://github.com/tang-vu/ContribAI), an AI agent
that helps improve open source projects. The change was:

1. **Discovered** by automated code analysis
2. **Generated** by AI with context-aware code generation
3. **Self-reviewed** by AI quality checks

If you have questions or feedback about this PR, please comment below.
We appreciate your time reviewing this contribution!

</details>


Closes #1792

## Summary by Sourcery

Ensure KMeans clustering in find_cluster_centroids validates input sizes and handles edge cases safely.

Bug Fixes:
- Prevent ValueError crashes by capping the number of clusters to the number of available embeddings and validating max_k.
- Reject empty embeddings and invalid max_k values with clear exceptions instead of failing at runtime.