### PR TITLE
Download GFPGAN enhancer model when missing

### DIFF
--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -1,6 +1,6 @@
 # Uses ONNX Runtime for GFPGAN face enhancement (no torch/gfpgan dependency)
 
-from typing import Any, List
+from typing import Any, List, Optional
 import cv2
 import threading
 import numpy as np
@@ -48,19 +48,26 @@ FFHQ_TEMPLATE_512 = np.array(
 
 
 def pre_check() -> bool:
+    model_path = ensure_model_available(report_status=True)
+    return model_path is not None
+
+
+def ensure_model_available(report_status: bool = False) -> Optional[str]:
     model_path = os.path.join(models_dir, MODEL_FILE)
     if not os.path.exists(model_path):
-        update_status(f"Downloading {MODEL_FILE}...", NAME)
+        if report_status:
+            update_status(f"Downloading {MODEL_FILE}...", NAME)
         conditional_download(models_dir, [MODEL_URL])
 
     if not os.path.exists(model_path):
-        update_status(
-            f"GFPGAN ONNX model not found at {model_path}. "
-            f"Download {MODEL_FILE} or place it in the models folder.",
-            NAME,
-        )
-        return False
-    return True
+        if report_status:
+            update_status(
+                f"Automatic download failed for {MODEL_FILE} from {MODEL_URL}. "
+                f"Place the model at {model_path} and try again.",
+                NAME,
+            )
+        return None
+    return model_path
 
 
 def pre_start() -> bool:
@@ -81,13 +88,13 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
 
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
-            model_path = os.path.join(models_dir, MODEL_FILE)
-
-            if not os.path.exists(model_path):
-                conditional_download(models_dir, [MODEL_URL])
-            if not os.path.exists(model_path):
+            model_path = ensure_model_available()
+            if model_path is None:
+                expected_model_path = os.path.join(models_dir, MODEL_FILE)
                 raise FileNotFoundError(
-                    f"{NAME}: Model not found at {model_path}"
+                    f"{NAME}: Automatic download failed for {MODEL_FILE} "
+                    f"from {MODEL_URL}. Place the model at "
+                    f"{expected_model_path} and try again."
                 )
 
             try:

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -14,6 +14,7 @@ from modules.core import update_status
 from modules.face_analyser import get_one_face, get_many_faces
 from modules.typing import Frame, Face
 from modules.utilities import (
+    conditional_download,
     is_image,
     is_video,
 )
@@ -22,6 +23,10 @@ FACE_ENHANCER = None
 THREAD_SEMAPHORE = threading.Semaphore()
 THREAD_LOCK = threading.Lock()
 NAME = "DLC.FACE-ENHANCER"
+MODEL_URL = (
+    "https://huggingface.co/hacksider/deep-live-cam/resolve/main/gfpgan-1024.onnx"
+)
+MODEL_FILE = "gfpgan-1024.onnx"
 
 abs_dir = os.path.dirname(os.path.abspath(__file__))
 models_dir = os.path.join(
@@ -43,11 +48,15 @@ FFHQ_TEMPLATE_512 = np.array(
 
 
 def pre_check() -> bool:
-    model_path = os.path.join(models_dir, "gfpgan-1024.onnx")
+    model_path = os.path.join(models_dir, MODEL_FILE)
+    if not os.path.exists(model_path):
+        update_status(f"Downloading {MODEL_FILE}...", NAME)
+        conditional_download(models_dir, [MODEL_URL])
+
     if not os.path.exists(model_path):
         update_status(
             f"GFPGAN ONNX model not found at {model_path}. "
-            "Please place gfpgan-1024.onnx in the models folder.",
+            f"Download {MODEL_FILE} or place it in the models folder.",
             NAME,
         )
         return False
@@ -72,8 +81,10 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
 
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
-            model_path = os.path.join(models_dir, "gfpgan-1024.onnx")
+            model_path = os.path.join(models_dir, MODEL_FILE)
 
+            if not os.path.exists(model_path):
+                conditional_download(models_dir, [MODEL_URL])
             if not os.path.exists(model_path):
                 raise FileNotFoundError(
                     f"{NAME}: Model not found at {model_path}"


### PR DESCRIPTION
## What

Make the default GFPGAN face enhancer download its required ONNX model when it is missing.

The GPEN enhancers and the face swapper already use `conditional_download()` for their model files, but `face_enhancer.py` only reported that `models/gfpgan-1024.onnx` had to be placed manually. This makes the default enhancer fail during pre-check even though the project already has the model downloader path used by adjacent processors.

This PR:

- defines the GFPGAN model filename and Hugging Face model URL in `face_enhancer.py`
- calls `conditional_download()` from `pre_check()` when the model is missing
- retries the same download during lazy ONNX session initialization before raising `FileNotFoundError`
- keeps the existing local-file preference: if `models/gfpgan-1024.onnx` already exists, no download is attempted

## Validation

- `python3 -m py_compile modules/processors/frame/face_enhancer.py`
- `git diff --check`
- targeted stub import test: monkey-patched the heavy runtime imports and verified `pre_check()` calls `conditional_download(models_dir, [MODEL_URL])` for a missing model and succeeds after the file appears
- verified the model URL resolves with an HTTP HEAD request

## Summary by Sourcery

Ensure the default GFPGAN face enhancer automatically retrieves its required ONNX model instead of requiring manual placement.

New Features:
- Add automatic download of the GFPGAN ONNX model when it is missing for the face enhancer processor.

Enhancements:
- Centralize the GFPGAN model filename and Hugging Face URL as constants shared by pre-check and runtime initialization.
- Improve error messaging when the GFPGAN model is not found, clarifying download or manual placement options.