### PR TITLE
fix: guard face swapper against invalid frames

### DIFF
--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -350,8 +350,23 @@ def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, 
     return target_img
 
 
+def _is_valid_frame(frame: Frame) -> bool:
+    """Return whether a frame has the array shape needed for swapping."""
+    if frame is None:
+        return False
+    if not all(hasattr(frame, attr) for attr in ("copy", "dtype", "shape")):
+        return False
+    try:
+        return len(frame.shape) >= 2
+    except TypeError:
+        return False
+
+
 def swap_face(source_face: Face, target_face: Face, temp_frame: Frame) -> Frame:
     """Optimized face swapping with better memory management and performance."""
+    if not _is_valid_frame(temp_frame):
+        return temp_frame
+
     face_swapper = get_face_swapper()
     if face_swapper is None:
         update_status("Face swapper model not loaded or failed to load. Skipping swap.", NAME)

--- a/tests/test_face_swapper_invalid_frame.py
+++ b/tests/test_face_swapper_invalid_frame.py
@@ -1,0 +1,118 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+def _install_import_stubs():
+    sys.modules.setdefault(
+        "cv2",
+        types.SimpleNamespace(
+            IMREAD_COLOR=1,
+            imread=lambda *_args, **_kwargs: None,
+            imdecode=lambda *_args, **_kwargs: None,
+            imencode=lambda *_args, **_kwargs: (True, types.SimpleNamespace(tofile=lambda *_a, **_k: None)),
+        ),
+    )
+    sys.modules.setdefault("insightface", types.SimpleNamespace())
+    sys.modules.setdefault(
+        "modules.globals",
+        types.SimpleNamespace(
+            execution_providers=[],
+            opacity=1.0,
+            mouth_mask=False,
+            many_faces=False,
+            dml_lock=types.SimpleNamespace(
+                __enter__=lambda self: self,
+                __exit__=lambda self, exc_type, exc, tb: False,
+            ),
+        ),
+    )
+    sys.modules.setdefault(
+        "modules.processors.frame.core",
+        types.SimpleNamespace(process_video=lambda *_args, **_kwargs: None),
+    )
+    sys.modules.setdefault(
+        "modules.core",
+        types.SimpleNamespace(update_status=lambda *_args, **_kwargs: None),
+    )
+    sys.modules.setdefault(
+        "modules.face_analyser",
+        types.SimpleNamespace(
+            get_one_face=lambda *_args, **_kwargs: None,
+            get_many_faces=lambda *_args, **_kwargs: [],
+            default_source_face=lambda *_args, **_kwargs: None,
+        ),
+    )
+    sys.modules.setdefault("modules.typing", types.SimpleNamespace(Face=object, Frame=object))
+    sys.modules.setdefault(
+        "modules.utilities",
+        types.SimpleNamespace(
+            conditional_download=lambda *_args, **_kwargs: None,
+            is_image=lambda *_args, **_kwargs: False,
+            is_video=lambda *_args, **_kwargs: False,
+        ),
+    )
+    sys.modules.setdefault(
+        "modules.cluster_analysis",
+        types.SimpleNamespace(find_closest_centroid=lambda *_args, **_kwargs: None),
+    )
+    sys.modules.setdefault(
+        "modules.gpu_processing",
+        types.SimpleNamespace(
+            gpu_gaussian_blur=lambda image, *_args, **_kwargs: image,
+            gpu_sharpen=lambda image, *_args, **_kwargs: image,
+            gpu_add_weighted=lambda *_args, **_kwargs: None,
+            gpu_resize=lambda image, *_args, **_kwargs: image,
+            gpu_cvt_color=lambda image, *_args, **_kwargs: image,
+        ),
+    )
+
+
+def _load_face_swapper():
+    _install_import_stubs()
+    sys.modules.pop("modules.processors.frame.face_swapper", None)
+    return importlib.import_module("modules.processors.frame.face_swapper")
+
+
+class FaceSwapperInvalidFrameTests(unittest.TestCase):
+    def test_swap_face_returns_none_frame_without_loading_model(self):
+        face_swapper = _load_face_swapper()
+
+        with patch.object(
+            face_swapper,
+            "get_face_swapper",
+            side_effect=AssertionError("should not load model for invalid frame"),
+        ):
+            self.assertIsNone(face_swapper.swap_face(object(), object(), None))
+
+    def test_swap_face_returns_object_without_array_shape(self):
+        face_swapper = _load_face_swapper()
+        invalid_frame = object()
+
+        with patch.object(
+            face_swapper,
+            "get_face_swapper",
+            side_effect=AssertionError("should not load model for invalid frame"),
+        ):
+            self.assertIs(face_swapper.swap_face(object(), object(), invalid_frame), invalid_frame)
+
+    def test_swap_face_returns_one_dimensional_frame_without_copying(self):
+        face_swapper = _load_face_swapper()
+        invalid_frame = types.SimpleNamespace(
+            shape=(3,),
+            dtype=object(),
+            copy=lambda: (_ for _ in ()).throw(AssertionError("should not copy invalid frame")),
+        )
+
+        with patch.object(
+            face_swapper,
+            "get_face_swapper",
+            side_effect=AssertionError("should not load model for invalid frame"),
+        ):
+            self.assertIs(face_swapper.swap_face(object(), object(), invalid_frame), invalid_frame)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an early frame-shape guard to `swap_face()` before model loading or frame copying
- return invalid frame inputs unchanged instead of raising before the existing swap `try` block
- cover `None`, non-array objects, and one-dimensional frame-like objects with focused unit tests

## Tests
- `python3 -m unittest tests/test_face_swapper_invalid_frame.py -v`
- `python3 -m py_compile modules/processors/frame/face_swapper.py tests/test_face_swapper_invalid_frame.py`
- `git diff --check origin/main...HEAD`

## Summary by Sourcery

Guard face swapping against invalid frame inputs and add tests for these cases.

Bug Fixes:
- Prevent swap_face from raising errors when given None, non-array objects, or one-dimensional frames by returning the input unchanged.

Tests:
- Add unit tests ensuring swap_face short-circuits without loading the model or copying when given invalid frames.