### PR TITLE
fix: keep DirectML face analysis on CPU

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -27,10 +27,7 @@ def get_face_analyser() -> Any:
         with FACE_ANALYSER_LOCK:
             # Double-check after acquiring lock
             if FACE_ANALYSER is None:
-                from modules.processors.frame._onnx_enhancer import (
-                    build_provider_config,
-                )
-                providers = build_provider_config()
+                providers = build_face_analyser_provider_config()
                 FACE_ANALYSER = insightface.app.FaceAnalysis(
                     name='buffalo_l',
                     providers=providers,
@@ -39,6 +36,24 @@ def get_face_analyser() -> Any:
                 FACE_ANALYSER.prepare(ctx_id=0, det_size=DET_SIZE)
                 _optimize_det_model(FACE_ANALYSER, providers)
     return FACE_ANALYSER
+
+
+def build_face_analyser_provider_config():
+    """Build provider config for InsightFace analysis models.
+
+    DirectML can still be used by the swapper/enhancer pipeline, but running
+    InsightFace detection/recognition on DirectML at the same time has been
+    reported to crash on AMD systems. Keep analysis on CPU for DirectML runs
+    while preserving the existing provider configuration for all other modes.
+    """
+    if _is_dml():
+        return ["CPUExecutionProvider"]
+
+    from modules.processors.frame._onnx_enhancer import (
+        build_provider_config,
+    )
+
+    return build_provider_config()
 
 
 def _optimize_det_model(fa: Any, providers) -> None:

--- a/tests/test_face_analyser_provider_config.py
+++ b/tests/test_face_analyser_provider_config.py
@@ -1,0 +1,80 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+def _install_import_stubs():
+    sys.modules.setdefault(
+        "insightface",
+        types.SimpleNamespace(app=types.SimpleNamespace(FaceAnalysis=object)),
+    )
+    sys.modules.setdefault(
+        "cv2",
+        types.SimpleNamespace(
+            IMREAD_COLOR=1,
+            imread=lambda *_args, **_kwargs: None,
+            imdecode=lambda *_args, **_kwargs: None,
+            imencode=lambda *_args, **_kwargs: (
+                True,
+                types.SimpleNamespace(tofile=lambda *_a, **_k: None),
+            ),
+        ),
+    )
+    sys.modules.setdefault(
+        "numpy",
+        types.SimpleNamespace(uint8=object, fromfile=lambda *_args, **_kwargs: b""),
+    )
+    sys.modules.setdefault(
+        "tqdm",
+        types.SimpleNamespace(tqdm=lambda iterable, **_kwargs: iterable),
+    )
+    sys.modules["modules.typing"] = types.SimpleNamespace(Frame=object)
+    sys.modules["modules.cluster_analysis"] = types.SimpleNamespace(
+        find_cluster_centroids=lambda *args, **kwargs: [],
+        find_closest_centroid=lambda *args, **kwargs: (0, None),
+    )
+    sys.modules["modules.utilities"] = types.SimpleNamespace(
+        get_temp_directory_path=lambda path: path,
+        create_temp=lambda path: None,
+        extract_frames=lambda path: None,
+        clean_temp=lambda path: None,
+        get_temp_frame_paths=lambda path: [],
+    )
+    sys.modules["modules.processors.frame._onnx_enhancer"] = types.SimpleNamespace(
+        build_provider_config=lambda providers=None: list(
+            providers
+            if providers is not None
+            else sys.modules["modules.globals"].execution_providers
+        ),
+    )
+
+
+def _load_face_analyser():
+    _install_import_stubs()
+    sys.modules.pop("modules.face_analyser", None)
+    return importlib.import_module("modules.face_analyser")
+
+
+class FaceAnalyserProviderConfigTests(unittest.TestCase):
+    def test_uses_cpu_provider_for_directml_face_analysis(self):
+        face_analyser = _load_face_analyser()
+        face_analyser.modules.globals.execution_providers = ["DmlExecutionProvider"]
+
+        self.assertEqual(
+            face_analyser.build_face_analyser_provider_config(),
+            ["CPUExecutionProvider"],
+        )
+
+    def test_preserves_existing_provider_config_for_non_directml(self):
+        face_analyser = _load_face_analyser()
+        face_analyser.modules.globals.execution_providers = ["CUDAExecutionProvider"]
+
+        self.assertEqual(
+            face_analyser.build_face_analyser_provider_config(),
+            ["CUDAExecutionProvider"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep InsightFace `FaceAnalysis` on `CPUExecutionProvider` when the app is running with DirectML
- preserve the existing provider configuration path for CUDA/CoreML/CPU runs
- add focused unittest coverage for DirectML and non-DirectML provider selection

## Why
DirectML users in #1690 reported that live preview / face swap can freeze or crash on AMD GPUs. One reproduction notes that running face analysis on CPU avoids the conflict while keeping the rest of the DirectML pipeline available.

Refs #1690

## Tests
- `python3 -m unittest tests.test_face_analyser_provider_config tests.test_face_analyser_get_one_face`
- `git diff --check origin/main...HEAD`

## Summary by Sourcery

Keep InsightFace face analysis on CPU when running with DirectML while preserving existing provider selection for other execution modes.

Bug Fixes:
- Avoid crashes and freezes on AMD GPUs by not running InsightFace face analysis on DirectML in DirectML pipelines.

Tests:
- Add unit tests to verify DirectML runs use CPU for face analysis and non-DirectML runs retain their existing provider configuration.