### PR TITLE
fix: clamp video preview frame seeks

### DIFF
--- a/modules/capturer.py
+++ b/modules/capturer.py
@@ -4,6 +4,22 @@ import modules.globals  # Import the globals to check the color correction toggl
 from modules.gpu_processing import gpu_cvt_color
 
 
+def get_video_frame_last_index(frame_total: Any) -> int:
+    try:
+        frame_total_int = int(frame_total)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return max(frame_total_int - 1, 0)
+
+
+def clamp_video_frame_number(frame_number: Any, frame_total: Any) -> int:
+    try:
+        frame_number_int = int(frame_number)
+    except (TypeError, ValueError, OverflowError):
+        frame_number_int = 0
+    return min(max(frame_number_int, 0), get_video_frame_last_index(frame_total))
+
+
 def get_video_frame(video_path: str, frame_number: int = 0) -> Any:
     capture = cv2.VideoCapture(video_path)
 
@@ -15,7 +31,7 @@ def get_video_frame(video_path: str, frame_number: int = 0) -> Any:
         capture.set(cv2.CAP_PROP_CONVERT_RGB, 1)
     
     frame_total = capture.get(cv2.CAP_PROP_FRAME_COUNT)
-    capture.set(cv2.CAP_PROP_POS_FRAMES, min(frame_total, frame_number - 1))
+    capture.set(cv2.CAP_PROP_POS_FRAMES, clamp_video_frame_number(frame_number, frame_total))
     has_frame, frame = capture.read()
 
     if has_frame and modules.globals.color_correction:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -25,7 +25,7 @@ from modules.face_analyser import (
     has_valid_map,
     simplify_maps,
 )
-from modules.capturer import get_video_frame, get_video_frame_total
+from modules.capturer import get_video_frame, get_video_frame_last_index, get_video_frame_total
 from modules.processors.frame.core import get_frame_processors_modules
 from modules.utilities import (
     is_image,
@@ -963,7 +963,7 @@ def init_preview() -> None:
         preview_slider.pack_forget()
     if is_video(modules.globals.target_path):
         video_frame_total = get_video_frame_total(modules.globals.target_path)
-        preview_slider.configure(to=video_frame_total)
+        preview_slider.configure(to=get_video_frame_last_index(video_frame_total))
         preview_slider.pack(fill="x")
         preview_slider.set(0)
 

--- a/tests/test_capturer_video_frame.py
+++ b/tests/test_capturer_video_frame.py
@@ -1,0 +1,80 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+class FakeCapture:
+    def __init__(self, frame_total):
+        self.frame_total = frame_total
+        self.set_calls = []
+        self.released = False
+
+    def set(self, prop, value):
+        self.set_calls.append((prop, value))
+        return True
+
+    def get(self, prop):
+        return self.frame_total
+
+    def read(self):
+        return True, "frame"
+
+    def release(self):
+        self.released = True
+
+
+def _load_capturer(captures):
+    cv2 = types.SimpleNamespace(
+        CAP_PROP_FOURCC=1,
+        CAP_PROP_CONVERT_RGB=2,
+        CAP_PROP_FRAME_COUNT=3,
+        CAP_PROP_POS_FRAMES=4,
+        COLOR_BGR2RGB=5,
+        IMREAD_COLOR=6,
+        imread=lambda *_args, **_kwargs: None,
+        imdecode=lambda *_args, **_kwargs: None,
+        imencode=lambda *_args, **_kwargs: (True, types.SimpleNamespace(tofile=lambda *_a, **_k: None)),
+        VideoWriter_fourcc=lambda *_args: 0,
+        VideoCapture=lambda _path: captures.pop(0),
+    )
+    sys.modules["cv2"] = cv2
+    sys.modules["numpy"] = types.SimpleNamespace(uint8=object, fromfile=lambda *_args, **_kwargs: b"")
+    globals_stub = types.SimpleNamespace(color_correction=False)
+    sys.modules["modules.globals"] = globals_stub
+    sys.modules["modules.gpu_processing"] = types.SimpleNamespace(gpu_cvt_color=lambda frame, _code: frame)
+    sys.modules.pop("modules.capturer", None)
+    modules_pkg = importlib.import_module("modules")
+    modules_pkg.globals = globals_stub
+    return importlib.import_module("modules.capturer"), cv2
+
+
+class CapturerVideoFrameTests(unittest.TestCase):
+    def test_uses_zero_based_frame_number_without_subtracting_one(self):
+        first = FakeCapture(frame_total=10)
+        second = FakeCapture(frame_total=10)
+        capturer, cv2 = _load_capturer([first, second])
+
+        self.assertEqual(capturer.get_video_frame("video.mp4", 0), "frame")
+        self.assertEqual(capturer.get_video_frame("video.mp4", 1), "frame")
+
+        self.assertIn((cv2.CAP_PROP_POS_FRAMES, 0), first.set_calls)
+        self.assertIn((cv2.CAP_PROP_POS_FRAMES, 1), second.set_calls)
+
+    def test_clamps_invalid_negative_and_beyond_last_frame_numbers(self):
+        first = FakeCapture(frame_total=10)
+        second = FakeCapture(frame_total=10)
+        third = FakeCapture(frame_total="not-a-number")
+        capturer, cv2 = _load_capturer([first, second, third])
+
+        capturer.get_video_frame("video.mp4", -3)
+        capturer.get_video_frame("video.mp4", 99)
+        capturer.get_video_frame("video.mp4", 5)
+
+        self.assertIn((cv2.CAP_PROP_POS_FRAMES, 0), first.set_calls)
+        self.assertIn((cv2.CAP_PROP_POS_FRAMES, 9), second.set_calls)
+        self.assertIn((cv2.CAP_PROP_POS_FRAMES, 0), third.set_calls)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `get_video_frame()` seek using zero-based frame numbers without subtracting one
- clamp negative and beyond-last preview frame requests to a valid frame index
- align the video preview slider maximum with the last zero-based frame index
- add mocked `VideoCapture` regression coverage for the frame seek boundary cases

## Why
The preview slider starts at `0`, but `get_video_frame()` was seeking to `frame_number - 1`. That makes the first preview frame seek to `-1` and shifts later slider values by one frame.

## Tests
- `python3 -m unittest tests.test_capturer_video_frame`
- `git diff --check origin/main...HEAD`

## Summary by Sourcery

Clamp video preview frame seeking to valid zero-based frame indices and align the UI slider range accordingly.

Bug Fixes:
- Fix off-by-one error in video frame seeking by using zero-based frame indices without subtracting one.
- Prevent invalid video frame seeks by clamping requested frame numbers to the valid frame range.

Tests:
- Add regression tests with a mocked VideoCapture to cover zero-based and out-of-range video frame seek behavior.