### PR TITLE
fix: guard unreadable source images in preview

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -927,6 +927,21 @@ def fit_image_to_size(image, width: int, height: int):
     return gpu_resize(image, dsize=new_size)
 
 
+def get_source_face():
+    if not modules.globals.source_path:
+        update_status("Please select a source image first.")
+        return None
+
+    source_frame = cv2.imread(modules.globals.source_path)
+    if source_frame is None:
+        update_status("Source image could not be read.")
+        return None
+
+    source_face = get_one_face(source_frame)
+    if source_face is None:
+        update_status("No face detected in source image.")
+    return source_face
+
 def render_image_preview(image_path: str, size: Tuple[int, int]) -> ctk.CTkImage:
     image = Image.open(image_path)
     if size:
@@ -971,15 +986,16 @@ def init_preview() -> None:
 def update_preview(frame_number: int = 0) -> None:
     if modules.globals.source_path and modules.globals.target_path:
         update_status("Processing...")
+        source_face = get_source_face()
+        if source_face is None:
+            return
         temp_frame = get_video_frame(modules.globals.target_path, frame_number)
         if modules.globals.nsfw_filter and check_and_ignore_nsfw(temp_frame):
             return
         for frame_processor in get_frame_processors_modules(
                 modules.globals.frame_processors
         ):
-            temp_frame = frame_processor.process_frame(
-                get_one_face(cv2.imread(modules.globals.source_path)), temp_frame
-            )
+            temp_frame = frame_processor.process_frame(source_face, temp_frame)
         image = Image.fromarray(gpu_cvt_color(temp_frame, cv2.COLOR_BGR2RGB))
         image = ImageOps.contain(
             image, (PREVIEW_MAX_WIDTH, PREVIEW_MAX_HEIGHT), Image.LANCZOS
@@ -1137,7 +1153,21 @@ def _processing_thread_func(capture_queue, processed_queue, stop_event,
         if not modules.globals.map_faces:
             if modules.globals.source_path and modules.globals.source_path != last_source_path:
                 last_source_path = modules.globals.source_path
-                source_image = get_one_face(cv2.imread(modules.globals.source_path))
+                source_image = get_source_face()
+
+            if modules.globals.source_path and source_image is None:
+                try:
+                    processed_queue.put_nowait(temp_frame)
+                except queue.Full:
+                    try:
+                        processed_queue.get_nowait()
+                    except queue.Empty:
+                        pass
+                    try:
+                        processed_queue.put_nowait(temp_frame)
+                    except queue.Full:
+                        pass
+                continue
 
             # Run detection every det_interval frames (~80ms).
             # Use fast detection (det-only, no landmark/recognition) for live mode.

--- a/tests/test_ui_source_face.py
+++ b/tests/test_ui_source_face.py
@@ -6,14 +6,23 @@ from unittest.mock import Mock, patch
 
 
 class StubModule(types.ModuleType):
+    def __init__(self, name, allowed_attrs=()):
+        super().__init__(name)
+        self._allowed_attrs = set(allowed_attrs)
+
     def __getattr__(self, name):
-        value = object
-        setattr(self, name, value)
-        return value
+        if name not in self._allowed_attrs:
+            raise AttributeError(
+                f"{name!r} is not a declared attribute of stub module "
+                f"{self.__name__!r}"
+            )
+        raise AttributeError(
+            f"{name!r} has not been set on stub module {self.__name__!r}"
+        )
 
 
 def _module(**attrs):
-    mod = StubModule("stub")
+    mod = StubModule("stub", allowed_attrs=attrs)
     for key, value in attrs.items():
         setattr(mod, key, value)
     return mod
@@ -22,16 +31,34 @@ def _module(**attrs):
 def _install_import_stubs():
     ctk = _module(
         CTk=object,
+        CTkButton=object,
         CTkImage=object,
+        CTkLabel=object,
+        CTkOptionMenu=object,
+        CTkScrollableFrame=object,
+        CTkSlider=object,
+        CTkSwitch=object,
+        CTkToplevel=object,
+        BooleanVar=object,
+        DoubleVar=object,
+        StringVar=object,
+        ThemeManager=object,
+        deactivate_automatic_dpi_awareness=lambda: None,
         filedialog=_module(askopenfilename=lambda **_kwargs: ""),
+        set_appearance_mode=lambda *_args, **_kwargs: None,
+        set_default_color_theme=lambda *_args, **_kwargs: None,
     )
     ctk.__path__ = []
     sys.modules.setdefault("customtkinter", ctk)
     dropdown_cls = type(
         "DropdownMenu", (), {"_add_menu_commands": lambda self, *args, **kwargs: None}
     )
-    sys.modules.setdefault("customtkinter.windows", _module())
-    sys.modules.setdefault("customtkinter.windows.widgets", _module())
+    windows_mod = _module()
+    windows_mod.__path__ = []
+    widgets_mod = _module()
+    widgets_mod.__path__ = []
+    sys.modules.setdefault("customtkinter.windows", windows_mod)
+    sys.modules.setdefault("customtkinter.windows.widgets", widgets_mod)
     sys.modules.setdefault(
         "customtkinter.windows.widgets.core_widget_classes",
         _module(DropdownMenu=dropdown_cls),

--- a/tests/test_ui_source_face.py
+++ b/tests/test_ui_source_face.py
@@ -1,0 +1,143 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+class StubModule(types.ModuleType):
+    def __getattr__(self, name):
+        value = object
+        setattr(self, name, value)
+        return value
+
+
+def _module(**attrs):
+    mod = StubModule("stub")
+    for key, value in attrs.items():
+        setattr(mod, key, value)
+    return mod
+
+
+def _install_import_stubs():
+    ctk = _module(
+        CTk=object,
+        CTkImage=object,
+        filedialog=_module(askopenfilename=lambda **_kwargs: ""),
+    )
+    ctk.__path__ = []
+    sys.modules.setdefault("customtkinter", ctk)
+    dropdown_cls = type(
+        "DropdownMenu", (), {"_add_menu_commands": lambda self, *args, **kwargs: None}
+    )
+    sys.modules.setdefault("customtkinter.windows", _module())
+    sys.modules.setdefault("customtkinter.windows.widgets", _module())
+    sys.modules.setdefault(
+        "customtkinter.windows.widgets.core_widget_classes",
+        _module(DropdownMenu=dropdown_cls),
+    )
+
+    image_mod = _module(open=lambda *_args, **_kwargs: object(), fromarray=lambda frame: frame)
+    image_ops_mod = _module(
+        fit=lambda image, *_args, **_kwargs: image,
+        contain=lambda image, *_args, **_kwargs: image,
+    )
+    sys.modules.setdefault("PIL", _module(Image=image_mod, ImageOps=image_ops_mod))
+    sys.modules.setdefault("PIL.Image", image_mod)
+    sys.modules.setdefault("PIL.ImageOps", image_ops_mod)
+
+    sys.modules.setdefault(
+        "cv2",
+        _module(
+            IMREAD_COLOR=1,
+            imread=lambda *_args, **_kwargs: None,
+            imdecode=lambda *_args, **_kwargs: None,
+            imencode=lambda *_args, **_kwargs: (
+                True,
+                _module(tofile=lambda *_args, **_kwargs: None),
+            ),
+            VideoCapture=lambda *_args, **_kwargs: _module(
+                isOpened=lambda: False, release=lambda: None
+            ),
+            destroyAllWindows=lambda: None,
+            COLOR_BGR2RGB=1,
+            CAP_PROP_POS_FRAMES=1,
+            FONT_HERSHEY_SIMPLEX=0,
+            putText=lambda *args, **kwargs: None,
+        ),
+    )
+    sys.modules.setdefault("numpy", _module(uint8=object, fromfile=lambda *_args, **_kwargs: b""))
+    sys.modules.setdefault("requests", _module(get=lambda *args, **kwargs: None))
+
+    globals_mod = _module(
+        file_types=(("Images", "*.png"), ("Videos", "*.mp4")),
+        source_path="/missing/source.png",
+        target_path="/tmp/target.png",
+        nsfw_filter=False,
+        frame_processors=[],
+        map_faces=False,
+        live_mirror=False,
+        many_faces=False,
+        fp_ui={},
+        show_fps=False,
+    )
+    sys.modules["modules.globals"] = globals_mod
+    import modules
+    modules.globals = globals_mod
+    sys.modules["modules.metadata"] = _module()
+    modules.metadata = sys.modules["modules.metadata"]
+    sys.modules["modules.gpu_processing"] = _module(
+        gpu_cvt_color=lambda frame, *_args, **_kwargs: frame,
+        gpu_resize=lambda frame, *args, **kwargs: frame,
+        gpu_flip=lambda frame, *_args, **_kwargs: frame,
+    )
+    sys.modules["modules.face_analyser"] = _module(
+        get_one_face=Mock(name="get_one_face"),
+        get_many_faces=lambda *_args, **_kwargs: [],
+        detect_one_face_fast=lambda *_args, **_kwargs: None,
+        detect_many_faces_fast=lambda *_args, **_kwargs: [],
+        get_unique_faces_from_target_image=lambda *_args, **_kwargs: [],
+        get_unique_faces_from_target_video=lambda *_args, **_kwargs: [],
+        add_blank_map=lambda *_args, **_kwargs: None,
+        has_valid_map=lambda *_args, **_kwargs: False,
+        simplify_maps=lambda *_args, **_kwargs: None,
+    )
+    sys.modules["modules.capturer"] = _module(
+        get_video_frame=lambda *_args, **_kwargs: None,
+        get_video_frame_total=lambda *_args, **_kwargs: 0,
+    )
+    sys.modules["modules.processors.frame.core"] = _module(
+        get_frame_processors_modules=lambda *_args, **_kwargs: []
+    )
+    sys.modules["modules.utilities"] = _module(
+        is_image=lambda path: True,
+        is_video=lambda path: False,
+        resolve_relative_path=lambda path: path,
+        has_image_extension=lambda path: True,
+    )
+    sys.modules["modules.video_capture"] = _module(VideoCapturer=object)
+    sys.modules["modules.gettext"] = _module(LanguageManager=lambda lang: _module(_=lambda text: text))
+    sys.modules["modules.ui_tooltip"] = _module(ToolTip=object)
+
+
+def _load_ui():
+    _install_import_stubs()
+    sys.modules.pop("modules.ui", None)
+    return importlib.import_module("modules.ui")
+
+
+class SourceFaceGuardTests(unittest.TestCase):
+    def test_unreadable_source_image_does_not_call_face_analyser(self):
+        ui = _load_ui()
+        ui.update_status = Mock()
+        ui.modules.globals.source_path = "/missing/source.png"
+
+        with patch.object(ui.cv2, "imread", return_value=None):
+            self.assertIsNone(ui.get_source_face())
+
+        ui.get_one_face.assert_not_called()
+        ui.update_status.assert_called_with("Source image could not be read.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a shared source-image face loader for preview paths
- stop preview processing early when the source image cannot be read or contains no face
- make live webcam preview keep showing the raw camera frame instead of passing an invalid source face into frame processors
- add a focused regression test proving unreadable source images do not call face analysis

## Why

The preview and webcam paths both called `get_one_face(cv2.imread(source_path))` directly. If the selected source image becomes unreadable (moved/deleted/corrupt), `cv2.imread()` returns `None` and the UI can pass an invalid frame into face analysis or downstream frame processors.

This keeps normal preview behavior unchanged for valid sources, but shows a clear status message and skips processing when the source image cannot be loaded.

## Validation

- `python3 -m unittest tests/test_ui_source_face.py`
- `python3 -m compileall modules/ui.py tests/test_ui_source_face.py`
- `git diff --check`

## Summary by Sourcery

Guard preview and live webcam paths against unreadable or faceless source images and add regression coverage.

Bug Fixes:
- Prevent preview processing from passing None or invalid source frames into face analysis when the source image is unreadable or contains no face.
- Ensure live webcam preview continues to display raw camera frames when the source image is invalid instead of feeding bad data into frame processors.

Tests:
- Add a regression test verifying that unreadable source images do not invoke face analysis and surface an appropriate status message.