### PR TITLE
fix: avoid Windows camera probing when none are listed

### DIFF
--- a/modules/camera_detection.py
+++ b/modules/camera_detection.py
@@ -1,0 +1,19 @@
+from collections.abc import Callable
+from typing import Protocol
+
+
+NO_CAMERAS_FOUND = "No cameras found"
+
+
+class _FilterGraph(Protocol):
+    def get_input_devices(self) -> list[str]:
+        ...
+
+
+def get_windows_cameras(filter_graph_factory: Callable[[], _FilterGraph]) -> tuple[list[int], list[str]]:
+    """Return DirectShow camera indices and names using a zero-argument FilterGraph factory."""
+    devices = filter_graph_factory().get_input_devices()
+    if not devices:
+        return [], [NO_CAMERAS_FOUND]
+
+    return list(range(len(devices))), devices

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -26,6 +26,7 @@ from modules.face_analyser import (
     simplify_maps,
 )
 from modules.capturer import get_video_frame, get_video_frame_total
+from modules.camera_detection import NO_CAMERAS_FOUND, get_windows_cameras
 from modules.processors.frame.core import get_frame_processors_modules
 from modules.utilities import (
     is_image,
@@ -366,12 +367,12 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
     available_cameras = get_available_cameras()
     camera_indices, camera_names = available_cameras
 
-    if not camera_names or camera_names[0] == "No cameras found":
-        camera_variable = ctk.StringVar(value="No cameras found")
+    if not camera_names or camera_names[0] == NO_CAMERAS_FOUND:
+        camera_variable = ctk.StringVar(value=NO_CAMERAS_FOUND)
         camera_optionmenu = ctk.CTkOptionMenu(
             root,
             variable=camera_variable,
-            values=["No cameras found"],
+            values=[NO_CAMERAS_FOUND],
             state="disabled",
         )
     else:
@@ -391,13 +392,13 @@ def create_root(start: Callable[[], None], destroy: Callable[[], None]) -> ctk.C
             root,
             (
                 camera_indices[camera_names.index(camera_variable.get())]
-                if camera_names and camera_names[0] != "No cameras found"
+                if camera_names and camera_names[0] != NO_CAMERAS_FOUND
                 else None
             ),
         ),
         state=(
             "normal"
-            if camera_names and camera_names[0] != "No cameras found"
+            if camera_names and camera_names[0] != NO_CAMERAS_FOUND
             else "disabled"
         ),
     )
@@ -1019,37 +1020,11 @@ def get_available_cameras():
     """Returns a list of available camera names and indices."""
     if platform.system() == "Windows":
         try:
-            graph = FilterGraph()
-            devices = graph.get_input_devices()
-
-            # Create list of indices and names
-            camera_indices = list(range(len(devices)))
-            camera_names = devices
-
-            # If no cameras found through DirectShow, try OpenCV fallback
-            if not camera_names:
-                # Try to open camera with index -1 and 0
-                test_indices = [-1, 0]
-                working_cameras = []
-
-                for idx in test_indices:
-                    cap = cv2.VideoCapture(idx)
-                    if cap.isOpened():
-                        working_cameras.append(f"Camera {idx}")
-                        cap.release()
-
-                if working_cameras:
-                    return test_indices[: len(working_cameras)], working_cameras
-
-            # If still no cameras found, return empty lists
-            if not camera_names:
-                return [], ["No cameras found"]
-
-            return camera_indices, camera_names
+            return get_windows_cameras(FilterGraph)
 
         except Exception as e:
             print(f"Error detecting cameras: {str(e)}")
-            return [], ["No cameras found"]
+            return [], [NO_CAMERAS_FOUND]
     else:
         # Unix-like systems (Linux/Mac) camera detection
         camera_indices = []
@@ -1072,7 +1047,7 @@ def get_available_cameras():
                     cap.release()
 
         if not camera_names:
-            return [], ["No cameras found"]
+            return [], [NO_CAMERAS_FOUND]
 
         return camera_indices, camera_names
 
@@ -1557,4 +1532,3 @@ def update_webcam_target(
         else:
             update_pop_live_status("Face could not be detected in last upload!")
         return map
-

--- a/tests/test_camera_detection.py
+++ b/tests/test_camera_detection.py
@@ -1,0 +1,32 @@
+import unittest
+
+from modules.camera_detection import NO_CAMERAS_FOUND, get_windows_cameras
+
+
+class WindowsCameraDetectionTests(unittest.TestCase):
+    def test_uses_directshow_devices_without_extra_probing(self):
+        def filter_graph_factory():
+            return _FilterGraph(["Integrated Camera", "USB Camera"])
+
+        self.assertEqual(
+            get_windows_cameras(filter_graph_factory),
+            ([0, 1], ["Integrated Camera", "USB Camera"]),
+        )
+
+    def test_empty_directshow_list_returns_disabled_state(self):
+        def filter_graph_factory():
+            return _FilterGraph([])
+
+        self.assertEqual(get_windows_cameras(filter_graph_factory), ([], [NO_CAMERAS_FOUND]))
+
+
+class _FilterGraph:
+    def __init__(self, devices):
+        self._devices = devices
+
+    def get_input_devices(self):
+        return self._devices
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stop probing OpenCV camera indices on Windows when DirectShow reports no input devices
- return the existing disabled "No cameras found" state instead, so the Live button stays disabled without emitting camera-index errors
- add a small unit test for the DirectShow camera-list helper

Fixes #1761.

## Tests
- `python3 -m unittest tests.test_camera_detection -v`
- `python3 -m unittest tests.test_face_analyser_get_one_face tests.test_camera_detection -v`
- `python3 -m py_compile modules/camera_detection.py modules/ui.py`

## Summary by Sourcery

Extract Windows camera detection into a reusable helper and stop probing OpenCV indices when DirectShow reports no devices.

Bug Fixes:
- Prevent spurious camera-index probing errors on Windows when no cameras are reported by DirectShow.

Enhancements:
- Introduce a dedicated camera_detection module for Windows camera enumeration and reuse it from the UI layer.

Tests:
- Add unit tests covering Windows camera detection behavior with and without DirectShow devices.