### PR TITLE
fix: accept directml execution provider alias

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -116,13 +116,27 @@ def parse_args() -> None:
         modules.globals.execution_threads = args.gpu_threads_deprecated
 
 
+EXECUTION_PROVIDER_ALIASES = {
+    'directml': 'dml',
+}
+
+
 def encode_execution_providers(execution_providers: List[str]) -> List[str]:
     return [execution_provider.replace('ExecutionProvider', '').lower() for execution_provider in execution_providers]
 
 
+def normalize_execution_provider(execution_provider: str) -> str:
+    return EXECUTION_PROVIDER_ALIASES.get(execution_provider, execution_provider)
+
+
+def normalize_execution_providers(execution_providers: List[str]) -> List[str]:
+    return [normalize_execution_provider(execution_provider) for execution_provider in execution_providers]
+
+
 def decode_execution_providers(execution_providers: List[str]) -> List[str]:
+    normalized_execution_providers = normalize_execution_providers(execution_providers)
     return [provider for provider, encoded_execution_provider in zip(onnxruntime.get_available_providers(), encode_execution_providers(onnxruntime.get_available_providers()))
-            if any(execution_provider in encoded_execution_provider for execution_provider in execution_providers)]
+            if any(execution_provider in encoded_execution_provider for execution_provider in normalized_execution_providers)]
 
 
 def suggest_max_memory() -> int:
@@ -141,7 +155,10 @@ def suggest_default_execution_provider() -> str:
 
 
 def suggest_execution_providers() -> List[str]:
-    return encode_execution_providers(onnxruntime.get_available_providers())
+    execution_providers = encode_execution_providers(onnxruntime.get_available_providers())
+    if 'dml' in execution_providers:
+        execution_providers.append('directml')
+    return execution_providers
 
 
 def suggest_execution_threads() -> int:

--- a/tests/test_execution_provider_aliases.py
+++ b/tests/test_execution_provider_aliases.py
@@ -1,0 +1,57 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+def _install_import_stubs():
+    sys.modules["torch"] = types.SimpleNamespace()
+    sys.modules["tensorflow"] = types.SimpleNamespace()
+    sys.modules["onnxruntime"] = types.SimpleNamespace(
+        get_available_providers=lambda: ["DmlExecutionProvider", "CPUExecutionProvider"],
+    )
+    sys.modules["modules.ui"] = types.SimpleNamespace()
+    sys.modules["modules.processors.frame.core"] = types.SimpleNamespace(
+        get_frame_processors_modules=lambda *_args, **_kwargs: [],
+        process_video_in_memory=lambda *_args, **_kwargs: None,
+    )
+    sys.modules["modules.utilities"] = types.SimpleNamespace(
+        has_image_extension=lambda *_args, **_kwargs: False,
+        is_image=lambda *_args, **_kwargs: False,
+        is_video=lambda *_args, **_kwargs: False,
+        detect_fps=lambda *_args, **_kwargs: 0,
+        create_video=lambda *_args, **_kwargs: None,
+        extract_frames=lambda *_args, **_kwargs: None,
+        get_temp_frame_paths=lambda *_args, **_kwargs: [],
+        restore_audio=lambda *_args, **_kwargs: None,
+        create_temp=lambda *_args, **_kwargs: None,
+        move_temp=lambda *_args, **_kwargs: None,
+        clean_temp=lambda *_args, **_kwargs: None,
+        normalize_output_path=lambda *_args, **_kwargs: None,
+    )
+
+
+def _load_core():
+    _install_import_stubs()
+    sys.modules.pop("modules.core", None)
+    return importlib.import_module("modules.core")
+
+
+class ExecutionProviderAliasTests(unittest.TestCase):
+    def test_directml_alias_decodes_to_dml_provider(self):
+        core = _load_core()
+
+        self.assertEqual(
+            core.decode_execution_providers(["directml"]),
+            ["DmlExecutionProvider"],
+        )
+
+    def test_directml_is_suggested_when_dml_is_available(self):
+        core = _load_core()
+
+        self.assertIn("dml", core.suggest_execution_providers())
+        self.assertIn("directml", core.suggest_execution_providers())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- accept `directml` as an alias for the existing `dml` execution provider
- keep `dml` behavior unchanged while listing `directml` when DirectML is available
- add focused unit coverage for decoding and suggested choices

Fixes #1292.

Tests:
- `python3 -m unittest tests.test_execution_provider_aliases -v`
- `git diff --check origin/main...HEAD`

## Summary by Sourcery

Add support for a `directml` alias for the existing DML execution provider and adjust provider suggestions accordingly.

New Features:
- Support `directml` as an alias for the `dml` execution provider in provider decoding and suggestion logic.

Tests:
- Add unit tests to verify decoding of the `directml` alias and that it is suggested when DML is available.