### PR TITLE
fix: measure camera fps without dropping startup frames

### DIFF
--- a/modules/video_capture.py
+++ b/modules/video_capture.py
@@ -167,12 +167,14 @@ class VideoCapturer:
                 return
 
             elapsed = now - self._fps_sample_started_at
-            if elapsed > 0:
-                # N frames contain N-1 frame intervals from the first timestamp
-                # to the current one.
-                self.actual_fps = (self._fps_sample_count - 1) / elapsed
+            if elapsed <= 0:
+                return
+
+            # N frames contain N-1 frame intervals from the first timestamp
+            # to the current one.
+            self.actual_fps = (self._fps_sample_count - 1) / elapsed
             self._fps_sample_done = True
-        except Exception:
+        except (OSError, RuntimeError, ValueError):
             self._fps_sample_done = True
 
     def set_frame_callback(self, callback: Callable[[np.ndarray], None]) -> None:

--- a/modules/video_capture.py
+++ b/modules/video_capture.py
@@ -23,6 +23,10 @@ class VideoCapturer:
         self.actual_width: int = 0
         self.actual_height: int = 0
         self.actual_fps: float = 0.0
+        self._fps_sample_target: int = 30
+        self._fps_sample_count: int = 0
+        self._fps_sample_started_at: Optional[float] = None
+        self._fps_sample_done: bool = False
 
         # Initialize Windows-specific components if on Windows
         if platform.system() == "Windows":
@@ -93,11 +97,14 @@ class VideoCapturer:
             self.actual_height = int(self.cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
 
             # CAP_PROP_FPS is unreliable on DirectShow — often reports 30
-            # even when the camera delivers 60.  Measure empirically by
-            # timing a burst of frames.
+            # even when the camera delivers 60.  Use it as an immediate
+            # startup value, then refine actual_fps from frames that callers
+            # already read.  Avoid doing a warmup+sample read burst here: that
+            # discards the first camera frames before live preview can consume
+            # them.
             reported_fps = self.cap.get(cv2.CAP_PROP_FPS)
-            self.actual_fps = self._measure_fps(warmup=10, sample=30,
-                                                fallback=reported_fps or fps)
+            self.actual_fps = reported_fps or fps
+            self._reset_fps_measurement(sample=30)
 
             print(f"[VideoCapturer] {self.actual_width}x{self.actual_height} "
                   f"@ {self.actual_fps:.1f}fps (reported={reported_fps:.0f})",
@@ -119,6 +126,7 @@ class VideoCapturer:
 
         ret, frame = self.cap.read()
         if ret:
+            self._record_fps_sample()
             self._current_frame = frame
             if self.frame_callback:
                 self.frame_callback(frame)
@@ -132,28 +140,40 @@ class VideoCapturer:
             self.is_running = False
             self.cap = None
 
-    def _measure_fps(self, warmup: int = 10, sample: int = 30,
-                     fallback: float = 30.0) -> float:
-        """Read warmup+sample frames and return measured FPS.
+    def _reset_fps_measurement(self, sample: int = 30) -> None:
+        """Prepare opportunistic FPS measurement without consuming frames."""
+        self._fps_sample_target = max(2, sample)
+        self._fps_sample_count = 0
+        self._fps_sample_started_at = None
+        self._fps_sample_done = False
 
-        This is more reliable than CAP_PROP_FPS which often lies on
-        DirectShow.  Takes ~0.5-1s at startup but gives a ground-truth
-        number for adaptive polling/detection intervals.
+    def _record_fps_sample(self) -> None:
+        """Update actual_fps from frames already delivered to callers.
+
+        Measuring in read() preserves the first live-preview frames while still
+        correcting backends whose CAP_PROP_FPS value is inaccurate.
         """
+        if self._fps_sample_done:
+            return
         try:
-            for _ in range(warmup):
-                self.cap.read()
-            t0 = time.perf_counter()
-            for _ in range(sample):
-                ret, _ = self.cap.read()
-                if not ret:
-                    return fallback
-            elapsed = time.perf_counter() - t0
-            if elapsed <= 0:
-                return fallback
-            return sample / elapsed
+            now = time.perf_counter()
+            if self._fps_sample_started_at is None:
+                self._fps_sample_started_at = now
+                self._fps_sample_count = 1
+                return
+
+            self._fps_sample_count += 1
+            if self._fps_sample_count < self._fps_sample_target:
+                return
+
+            elapsed = now - self._fps_sample_started_at
+            if elapsed > 0:
+                # N frames contain N-1 frame intervals from the first timestamp
+                # to the current one.
+                self.actual_fps = (self._fps_sample_count - 1) / elapsed
+            self._fps_sample_done = True
         except Exception:
-            return fallback
+            self._fps_sample_done = True
 
     def set_frame_callback(self, callback: Callable[[np.ndarray], None]) -> None:
         """Set callback for frame processing"""

--- a/tests/test_video_capture_fps_probe.py
+++ b/tests/test_video_capture_fps_probe.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 
 class FakeCapture:
-    def __init__(self):
+    def __init__(self, cv2_module=None):
+        self.cv2 = cv2_module
         self.read_count = 0
         self.set_calls = []
         self.opened = True
@@ -20,11 +21,11 @@ class FakeCapture:
         return True
 
     def get(self, prop):
-        if prop == 3:
+        if prop == self.cv2.CAP_PROP_FRAME_WIDTH:
             return 960
-        if prop == 4:
+        if prop == self.cv2.CAP_PROP_FRAME_HEIGHT:
             return 540
-        if prop == 5:
+        if prop == self.cv2.CAP_PROP_FPS:
             return 30
         return 0
 
@@ -48,6 +49,7 @@ def import_video_capture(fake_capture):
         VideoWriter_fourcc=lambda *_args: 1196444237,
         VideoCapture=lambda *_args, **_kwargs: fake_capture,
     )
+    fake_capture.cv2 = fake_cv2
     module_path = Path(__file__).resolve().parents[1] / "modules" / "video_capture.py"
     module_name = "video_capture_under_test"
     fake_numpy = types.SimpleNamespace(ndarray=object)
@@ -71,6 +73,26 @@ class VideoCaptureFpsProbeTests(unittest.TestCase):
         self.assertEqual(0, fake_capture.read_count)
         self.assertEqual(30, capturer.actual_fps)
         self.assertTrue(capturer.is_running)
+
+    def test_actual_fps_keeps_sampling_when_elapsed_is_zero(self):
+        fake_capture = FakeCapture()
+        video_capture = import_video_capture(fake_capture)
+        ticks = iter([0.0] * 30 + [0.1])
+
+        with patch.object(video_capture.platform, "system", return_value="Linux"):
+            with patch.object(video_capture.time, "perf_counter", side_effect=lambda: next(ticks)):
+                capturer = video_capture.VideoCapturer(0)
+                self.assertTrue(capturer.start())
+                for _ in range(30):
+                    capturer.read()
+
+                self.assertFalse(capturer._fps_sample_done)
+                self.assertEqual(30, capturer.actual_fps)
+
+                capturer.read()
+
+        self.assertTrue(capturer._fps_sample_done)
+        self.assertAlmostEqual(300.0, capturer.actual_fps)
 
     def test_actual_fps_updates_from_delivered_frames(self):
         fake_capture = FakeCapture()

--- a/tests/test_video_capture_fps_probe.py
+++ b/tests/test_video_capture_fps_probe.py
@@ -1,0 +1,93 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class FakeCapture:
+    def __init__(self):
+        self.read_count = 0
+        self.set_calls = []
+        self.opened = True
+
+    def isOpened(self):
+        return self.opened
+
+    def set(self, prop, value):
+        self.set_calls.append((prop, value))
+        return True
+
+    def get(self, prop):
+        if prop == 3:
+            return 960
+        if prop == 4:
+            return 540
+        if prop == 5:
+            return 30
+        return 0
+
+    def read(self):
+        self.read_count += 1
+        return True, f"frame-{self.read_count}"
+
+    def release(self):
+        self.opened = False
+
+
+def import_video_capture(fake_capture):
+    fake_cv2 = types.SimpleNamespace(
+        CAP_PROP_FRAME_WIDTH=3,
+        CAP_PROP_FRAME_HEIGHT=4,
+        CAP_PROP_FPS=5,
+        CAP_PROP_FOURCC=6,
+        CAP_DSHOW=700,
+        CAP_MSMF=1400,
+        CAP_ANY=0,
+        VideoWriter_fourcc=lambda *_args: 1196444237,
+        VideoCapture=lambda *_args, **_kwargs: fake_capture,
+    )
+    module_path = Path(__file__).resolve().parents[1] / "modules" / "video_capture.py"
+    module_name = "video_capture_under_test"
+    fake_numpy = types.SimpleNamespace(ndarray=object)
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(sys.modules, {"cv2": fake_cv2, "numpy": fake_numpy, module_name: module}):
+        spec.loader.exec_module(module)
+    return module
+
+
+class VideoCaptureFpsProbeTests(unittest.TestCase):
+    def test_start_does_not_consume_frames_for_fps_probe(self):
+        fake_capture = FakeCapture()
+        video_capture = import_video_capture(fake_capture)
+
+        with patch.object(video_capture.platform, "system", return_value="Linux"):
+            capturer = video_capture.VideoCapturer(0)
+            self.assertTrue(capturer.start())
+
+        self.assertEqual(0, fake_capture.read_count)
+        self.assertEqual(30, capturer.actual_fps)
+        self.assertTrue(capturer.is_running)
+
+    def test_actual_fps_updates_from_delivered_frames(self):
+        fake_capture = FakeCapture()
+        video_capture = import_video_capture(fake_capture)
+        ticks = iter(i * 0.1 for i in range(30))
+
+        with patch.object(video_capture.platform, "system", return_value="Linux"):
+            with patch.object(video_capture.time, "perf_counter", side_effect=lambda: next(ticks)):
+                capturer = video_capture.VideoCapturer(0)
+                self.assertTrue(capturer.start())
+                frames = [capturer.read()[1] for _ in range(30)]
+
+        self.assertEqual("frame-1", frames[0])
+        self.assertEqual("frame-30", frames[-1])
+        self.assertEqual(30, fake_capture.read_count)
+        self.assertAlmostEqual(10.0, capturer.actual_fps)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Avoid consuming a warmup/sample burst in `VideoCapturer.start()` before live preview can read frames.
- Keep the immediate reported-FPS startup value, then refine `actual_fps` opportunistically from frames already returned by `read()`.
- Add regression tests proving startup does not call `read()` for FPS probing and that delivered frames still update `actual_fps`.

## Tests

- `python3 -m unittest tests/test_video_capture_fps_probe.py -v`
- `python3 -m py_compile modules/video_capture.py tests/test_video_capture_fps_probe.py`
- `git diff --check`

## Summary by Sourcery

Update video capture FPS handling to avoid consuming startup frames while still refining actual frame rate during normal reads.

New Features:
- Add opportunistic FPS measurement that refines actual_fps based on frames returned by read() rather than a dedicated sampling burst.

Bug Fixes:
- Prevent VideoCapturer.start() from consuming and discarding initial camera frames when probing FPS, preserving frames for live preview.

Tests:
- Add unit tests to verify start() no longer performs read()-based FPS probing and that actual_fps is updated from delivered frames.