### PR TITLE
Pre-load NVIDIA shared libraries on Linux

### DIFF
--- a/run.py
+++ b/run.py
@@ -52,10 +52,13 @@ if sys.platform.startswith("linux"):
             _lib_dir = os.path.join(_nvidia_dir, _pkg, "lib")
             if not os.path.isdir(_lib_dir):
                 continue
-            # Also expose the directory to child processes
-            os.environ["LD_LIBRARY_PATH"] = (
-                _lib_dir + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
-            )
+            # Also expose the directory to child processes, without
+            # duplicating an entry that is already present.
+            _ldp = os.environ.get("LD_LIBRARY_PATH", "")
+            if _lib_dir not in _ldp.split(os.pathsep):
+                os.environ["LD_LIBRARY_PATH"] = (
+                    _lib_dir + (os.pathsep + _ldp if _ldp else "")
+                )
             for _so in sorted(glob.glob(os.path.join(_lib_dir, "lib*.so*"))):
                 try:
                     ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)

--- a/run.py
+++ b/run.py
@@ -31,6 +31,38 @@ if sys.platform == "win32":
             except (OSError, AttributeError):
                 pass
 
+# On Linux, pre-load NVIDIA shared libraries (cuDNN, cuBLAS, nvrtc...) shipped
+# inside the venv via pip wheels (nvidia-cudnn-cu12, etc.). LD_LIBRARY_PATH
+# cannot be set after Python starts, so we use ctypes.CDLL with RTLD_GLOBAL
+# instead. This makes symbols available to onnxruntime when it dlopens its
+# CUDA provider.
+if sys.platform.startswith("linux"):
+    import ctypes
+    import glob
+    _py_lib = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    _site_packages_candidates = [
+        os.path.join(project_root, "venv", "lib", _py_lib, "site-packages"),
+        os.path.join(sys.prefix, "lib", _py_lib, "site-packages"),
+    ]
+    for _sp in _site_packages_candidates:
+        _nvidia_dir = os.path.join(_sp, "nvidia")
+        if not os.path.isdir(_nvidia_dir):
+            continue
+        for _pkg in os.listdir(_nvidia_dir):
+            _lib_dir = os.path.join(_nvidia_dir, _pkg, "lib")
+            if not os.path.isdir(_lib_dir):
+                continue
+            # Also expose the directory to child processes
+            os.environ["LD_LIBRARY_PATH"] = (
+                _lib_dir + os.pathsep + os.environ.get("LD_LIBRARY_PATH", "")
+            )
+            for _so in sorted(glob.glob(os.path.join(_lib_dir, "lib*.so*"))):
+                try:
+                    ctypes.CDLL(_so, mode=ctypes.RTLD_GLOBAL)
+                except OSError:
+                    pass
+        break
+
 from modules import platform_info
 platform_info.print_banner()
 


### PR DESCRIPTION
Mirrors #1775 for Linux. That PR added the Windows preload block and noted Linux relies on loader paths, but this breaks for pip-only installs: when `nvidia-cudnn-cu12` and friends sit under `venv/lib/pythonX.Y/site-packages/nvidia/`, the dynamic linker never sees them, and `LD_LIBRARY_PATH` cannot be set after Python starts.

Fix: `ctypes.CDLL(..., RTLD_GLOBAL)` on every `lib*.so*` under those wheel dirs before `onnxruntime` loads its CUDA provider. Also prepends `LD_LIBRARY_PATH` for child processes (ffmpeg).

Resolves:
```
Failed to load library libonnxruntime_providers_cuda.so: libcudnn.so.9: cannot open shared object file
```

No-op on Windows/macOS and when the wheel dirs are absent.

## Summary by Sourcery

Pre-load NVIDIA CUDA-related shared libraries from Python wheel directories on Linux before initializing ONNX Runtime, ensuring the CUDA provider can locate its dependencies in virtualenv-only installs.

New Features:
- Introduce Linux-specific preloading of NVIDIA CUDA shared libraries using ctypes to make them visible to the dynamic linker in virtualenv and pip-only environments.

Enhancements:
- Propagate the NVIDIA library paths to child processes via LD_LIBRARY_PATH so tools like ffmpeg can access the same CUDA libraries.
- Keep behavior a no-op on non-Linux platforms or when NVIDIA wheel directories are not present to avoid affecting other environments.