### PR TITLE
fix: derive default threads from selected provider

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -56,9 +56,10 @@ def parse_args() -> None:
     program.add_argument('-l', '--lang', help='Ui language', default="en")
     program.add_argument('--live-mirror', help='The live camera display as you see it in the front-facing camera frame', dest='live_mirror', action='store_true', default=False)
     program.add_argument('--live-resizable', help='The live camera frame is resizable', dest='live_resizable', action='store_true', default=False)
+    default_execution_provider = suggest_default_execution_provider()
     program.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
-    program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=[suggest_default_execution_provider()], choices=suggest_execution_providers(), nargs='+')
-    program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
+    program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=[default_execution_provider], choices=suggest_execution_providers(), nargs='+')
+    program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads([default_execution_provider]))
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
 
     # register deprecated args
@@ -144,20 +145,22 @@ def suggest_execution_providers() -> List[str]:
     return encode_execution_providers(onnxruntime.get_available_providers())
 
 
-def suggest_execution_threads() -> int:
+def suggest_execution_threads(execution_providers: List[str] | None = None) -> int:
     """Suggest optimal thread count based on hardware and execution provider."""
     import os
-    
+
     # Get CPU count
     cpu_count = os.cpu_count() or 4
-    
-    if 'DmlExecutionProvider' in modules.globals.execution_providers:
+    selected_execution_providers = execution_providers or modules.globals.execution_providers
+    encoded_execution_providers = encode_execution_providers(selected_execution_providers)
+
+    if 'dml' in encoded_execution_providers:
         return 1
-    if 'ROCMExecutionProvider' in modules.globals.execution_providers:
+    if 'rocm' in encoded_execution_providers:
         return 1
-    if 'CUDAExecutionProvider' in modules.globals.execution_providers:
+    if 'cuda' in encoded_execution_providers:
         return 2
-    
+
     # For CPU execution, use most cores but leave some for system
     return max(4, min(cpu_count - 2, 16))
 

--- a/tests/test_core_parse_args_defaults.py
+++ b/tests/test_core_parse_args_defaults.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+
+def _load_core_module(available_providers: list[str]):
+    repo_root = Path(__file__).resolve().parent.parent
+
+    fake_modules = types.ModuleType("modules")
+    fake_modules.__path__ = [str(repo_root / "modules")]
+
+    fake_onnxruntime = types.ModuleType("onnxruntime")
+    fake_onnxruntime.get_available_providers = lambda: available_providers
+
+    fake_tensorflow = types.ModuleType("tensorflow")
+    fake_tensorflow.config = types.SimpleNamespace(
+        experimental=types.SimpleNamespace(
+            list_physical_devices=lambda *_: [],
+            set_memory_growth=lambda *_: None,
+        )
+    )
+
+    fake_metadata = types.ModuleType("modules.metadata")
+    fake_metadata.name = "Deep-Live-Cam"
+    fake_metadata.version = "test"
+
+    fake_ui = types.ModuleType("modules.ui")
+
+    fake_processors = types.ModuleType("modules.processors")
+    fake_processors.__path__ = [str(repo_root / "modules" / "processors")]
+    fake_frame = types.ModuleType("modules.processors.frame")
+    fake_frame.__path__ = [str(repo_root / "modules" / "processors" / "frame")]
+    fake_frame_core = types.ModuleType("modules.processors.frame.core")
+    fake_frame_core.get_frame_processors_modules = lambda *_: []
+    fake_frame_core.process_video_in_memory = lambda *_, **__: None
+
+    fake_utilities = types.ModuleType("modules.utilities")
+    fake_utilities.has_image_extension = lambda *_: False
+    fake_utilities.is_image = lambda *_: False
+    fake_utilities.is_video = lambda *_: False
+    fake_utilities.detect_fps = lambda *_: 0
+    fake_utilities.create_video = lambda *_, **__: None
+    fake_utilities.extract_frames = lambda *_, **__: None
+    fake_utilities.get_temp_frame_paths = lambda *_: []
+    fake_utilities.restore_audio = lambda *_, **__: None
+    fake_utilities.create_temp = lambda *_, **__: None
+    fake_utilities.move_temp = lambda *_, **__: None
+    fake_utilities.clean_temp = lambda *_, **__: None
+    fake_utilities.normalize_output_path = lambda source, target, output: output
+
+    fake_globals = types.ModuleType("modules.globals")
+    fake_globals.execution_providers = []
+    fake_globals.fp_ui = {
+        "face_enhancer": False,
+        "face_enhancer_gpen256": False,
+        "face_enhancer_gpen512": False,
+    }
+
+    fake_modules.globals = fake_globals
+    fake_modules.metadata = fake_metadata
+    fake_modules.ui = fake_ui
+
+    for module_name in [
+        "modules",
+        "modules.core",
+        "modules.globals",
+        "modules.metadata",
+        "modules.ui",
+        "modules.processors",
+        "modules.processors.frame",
+        "modules.processors.frame.core",
+        "modules.utilities",
+    ]:
+        sys.modules.pop(module_name, None)
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "modules": fake_modules,
+            "onnxruntime": fake_onnxruntime,
+            "tensorflow": fake_tensorflow,
+            "modules.globals": fake_globals,
+            "modules.metadata": fake_metadata,
+            "modules.ui": fake_ui,
+            "modules.processors": fake_processors,
+            "modules.processors.frame": fake_frame,
+            "modules.processors.frame.core": fake_frame_core,
+            "modules.utilities": fake_utilities,
+        },
+    ):
+        return importlib.import_module("modules.core"), fake_globals
+
+
+def test_default_execution_threads_follow_cuda_default_provider() -> None:
+    core, globals_module = _load_core_module(
+        ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+
+    with (
+        mock.patch.object(sys, "argv", ["run.py"]),
+        mock.patch("os.cpu_count", return_value=12),
+    ):
+        core.parse_args()
+
+    assert globals_module.execution_providers == ["CUDAExecutionProvider"]
+    assert globals_module.execution_threads == 2
+
+
+def test_default_execution_threads_follow_cpu_provider() -> None:
+    core, globals_module = _load_core_module(["CPUExecutionProvider"])
+
+    with (
+        mock.patch.object(sys, "argv", ["run.py"]),
+        mock.patch("os.cpu_count", return_value=12),
+    ):
+        core.parse_args()
+
+    assert globals_module.execution_providers == ["CPUExecutionProvider"]
+    assert globals_module.execution_threads == 10

--- a/tests/test_core_parse_args_defaults.py
+++ b/tests/test_core_parse_args_defaults.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def _load_core_module(available_providers: list[str]):
+    repo_root = Path(__file__).resolve().parent.parent
+
+    fake_modules = types.ModuleType("modules")
+    fake_modules.__path__ = [str(repo_root / "modules")]
+
+    fake_onnxruntime = types.ModuleType("onnxruntime")
+    fake_onnxruntime.get_available_providers = lambda: available_providers
+
+    fake_tensorflow = types.ModuleType("tensorflow")
+    fake_tensorflow.config = types.SimpleNamespace(
+        experimental=types.SimpleNamespace(
+            list_physical_devices=lambda *_: [],
+            set_memory_growth=lambda *_: None,
+        )
+    )
+
+    fake_metadata = types.ModuleType("modules.metadata")
+    fake_metadata.name = "Deep-Live-Cam"
+    fake_metadata.version = "test"
+
+    fake_ui = types.ModuleType("modules.ui")
+
+    fake_processors = types.ModuleType("modules.processors")
+    fake_processors.__path__ = [str(repo_root / "modules" / "processors")]
+    fake_frame = types.ModuleType("modules.processors.frame")
+    fake_frame.__path__ = [str(repo_root / "modules" / "processors" / "frame")]
+    fake_frame_core = types.ModuleType("modules.processors.frame.core")
+    fake_frame_core.get_frame_processors_modules = lambda *_: []
+    fake_frame_core.process_video_in_memory = lambda *_, **__: None
+
+    fake_utilities = types.ModuleType("modules.utilities")
+    fake_utilities.has_image_extension = lambda *_: False
+    fake_utilities.is_image = lambda *_: False
+    fake_utilities.is_video = lambda *_: False
+    fake_utilities.detect_fps = lambda *_: 0
+    fake_utilities.create_video = lambda *_, **__: None
+    fake_utilities.extract_frames = lambda *_, **__: None
+    fake_utilities.get_temp_frame_paths = lambda *_: []
+    fake_utilities.restore_audio = lambda *_, **__: None
+    fake_utilities.create_temp = lambda *_, **__: None
+    fake_utilities.move_temp = lambda *_, **__: None
+    fake_utilities.clean_temp = lambda *_, **__: None
+    fake_utilities.normalize_output_path = lambda source, target, output: output
+
+    fake_globals = types.ModuleType("modules.globals")
+    fake_globals.execution_providers = []
+    fake_globals.fp_ui = {
+        "face_enhancer": False,
+        "face_enhancer_gpen256": False,
+        "face_enhancer_gpen512": False,
+    }
+
+    fake_modules.globals = fake_globals
+    fake_modules.metadata = fake_metadata
+    fake_modules.ui = fake_ui
+
+    module_names = [
+        "modules",
+        "modules.core",
+        "modules.globals",
+        "modules.metadata",
+        "modules.ui",
+        "modules.processors",
+        "modules.processors.frame",
+        "modules.processors.frame.core",
+        "modules.utilities",
+    ]
+    original_modules = {name: sys.modules[name] for name in module_names if name in sys.modules}
+    try:
+        for module_name in module_names:
+            sys.modules.pop(module_name, None)
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "modules": fake_modules,
+                "onnxruntime": fake_onnxruntime,
+                "tensorflow": fake_tensorflow,
+                "modules.globals": fake_globals,
+                "modules.metadata": fake_metadata,
+                "modules.ui": fake_ui,
+                "modules.processors": fake_processors,
+                "modules.processors.frame": fake_frame,
+                "modules.processors.frame.core": fake_frame_core,
+                "modules.utilities": fake_utilities,
+            },
+        ):
+            return importlib.import_module("modules.core"), fake_globals
+    finally:
+        for module_name in module_names:
+            sys.modules.pop(module_name, None)
+        sys.modules.update(original_modules)
+
+
+def test_default_execution_threads_follow_cuda_default_provider() -> None:
+    core, globals_module = _load_core_module(
+        ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+
+    with (
+        mock.patch.object(sys, "argv", ["run.py"]),
+        mock.patch("os.cpu_count", return_value=12),
+    ):
+        core.parse_args()
+
+    assert globals_module.execution_providers == ["CUDAExecutionProvider"]
+    assert globals_module.execution_threads == 2
+
+
+def test_default_execution_threads_follow_cpu_provider() -> None:
+    core, globals_module = _load_core_module(["CPUExecutionProvider"])
+
+    with (
+        mock.patch.object(sys, "argv", ["run.py"]),
+        mock.patch("os.cpu_count", return_value=12),
+    ):
+        core.parse_args()
+
+    assert globals_module.execution_providers == ["CPUExecutionProvider"]
+    assert globals_module.execution_threads == 10
+
+
+@pytest.mark.parametrize("provider", ["DmlExecutionProvider", "ROCMExecutionProvider"])
+def test_default_execution_threads_follow_single_thread_gpu_providers(provider: str) -> None:
+    core, globals_module = _load_core_module([provider, "CPUExecutionProvider"])
+
+    with (
+        mock.patch.object(sys, "argv", ["run.py"]),
+        mock.patch("os.cpu_count", return_value=12),
+    ):
+        core.parse_args()
+
+    assert globals_module.execution_providers == [provider]
+    assert globals_module.execution_threads == 1


### PR DESCRIPTION
## Summary
- compute the default execution provider once before registering CLI defaults
- derive the default execution thread count from that selected provider instead of the still-empty global provider list
- add regression coverage for CUDA and CPU default parsing paths

## Tests
- `python3 -m pytest tests/test_core_parse_args_defaults.py tests/test_face_analyser_get_one_face.py -q`

## Summary by Sourcery

Align default execution threads with the initially selected execution provider when parsing core CLI arguments.

Bug Fixes:
- Fix default execution thread selection to use the suggested default execution provider instead of an empty global provider list.

Tests:
- Add regression tests to verify default execution provider and thread count for CUDA and CPU configurations when parsing CLI arguments.