### PR TITLE
feat: webp image support

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -7,7 +7,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 WORKFLOW_DIR = os.path.join(ROOT_DIR, "workflow")
 
 file_types = [
-    ("Image", ("*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp")),
+    ("Image", ("*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp", "*.webp")),
     ("Video", ("*.mp4", "*.mkv")),
 ]
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -733,7 +733,7 @@ class MainWindow(QMainWindow):
         path, _filter = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp)",
+            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
         )
         if path and is_image(path):
             modules.globals.source_path = path
@@ -754,7 +754,7 @@ class MainWindow(QMainWindow):
         path, _filter = QFileDialog.getOpenFileName(
             self, _("select an target image or video"),
             _RECENT_TARGET_DIR or "",
-            "Media (*.png *.jpg *.jpeg *.gif *.bmp *.mp4 *.mkv)",
+            "Media (*.png *.jpg *.jpeg *.gif *.bmp *.webp *.mp4 *.mkv)",
         )
         if not path:
             return
@@ -885,7 +885,7 @@ class MainWindow(QMainWindow):
             path, _f = QFileDialog.getSaveFileName(
                 self, _("save image output file"),
                 os.path.join(_RECENT_OUTPUT_DIR or "", "output.png"),
-                "Images (*.png *.jpg *.jpeg *.bmp)",
+                "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
             )
         elif is_video(modules.globals.target_path):
             path, _f = QFileDialog.getSaveFileName(
@@ -1333,7 +1333,7 @@ class MapperDialog(QDialog):
         path, _f = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp)",
+            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
         )
         if not path:
             return
@@ -1438,7 +1438,7 @@ class LiveMapperDialog(QDialog):
         path, _f = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp)",
+            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
         )
         if not path:
             return

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -262,11 +262,14 @@ def clean_temp(target_path: str) -> None:
 
 
 def has_image_extension(image_path: str) -> bool:
-    return image_path.lower().endswith(("png", "jpg", "jpeg"))
+    return image_path.lower().endswith(("png", "jpg", "jpeg", "gif", "bmp", "webp"))
 
 
 def is_image(image_path: str) -> bool:
     if image_path and os.path.isfile(image_path):
+        # Extension check first — Windows mimetypes doesn't always register webp
+        if has_image_extension(image_path):
+            return True
         mimetype, _ = mimetypes.guess_type(image_path)
         return bool(mimetype and mimetype.startswith("image/"))
     return False


### PR DESCRIPTION
## Summary

Adds `.webp` to the set of accepted image formats for source/target/output across the codebase. Also lifts `.gif` and `.bmp` into `has_image_extension()` to match the formats already accepted by the file dialogs.

## Why

Lots of source faces these days come from web pages or image search and land on disk as `.webp` (Google Images saves WebP by default; iOS and Android Chrome export WebP). Currently those files get filtered out of the source/target pickers and rejected by `is_image()`, forcing a manual format conversion before they can be used.

## What changed

- **`modules/utilities.py`**
  - `has_image_extension()` now matches `.png/.jpg/.jpeg/.gif/.bmp/.webp` (was only the first three).
  - `is_image()` checks the extension via `has_image_extension()` before falling back to `mimetypes`. Windows `mimetypes` doesn't register `image/webp` by default on a stock install, so the mimetypes path returned `False` for valid WebPs. Extension check first fixes that without breaking the existing mimetype path for other formats.
- **`modules/globals.py`** — `file_types` Image tuple gains `*.webp`.
- **`modules/ui.py`** — five `QFileDialog` filter strings updated to include `*.webp` (source picker, target picker, save dialog, MapperDialog source, LiveMapperDialog source). The save-image dialog also picks up `.gif` for consistency with the read filters.

## Test plan

- [ ] Drop a `.webp` source face on the source slot → loads + previews
- [ ] Pick a `.webp` via the source file dialog → file appears in the picker, loads on select
- [ ] Save output to a `.webp` via the save dialog → file written, opens in image viewer
- [ ] Existing `.png/.jpg/.jpeg/.gif/.bmp` paths still work unchanged

No new dependencies (cv2 and PIL both read WebP natively in the versions already pinned).

## Summary by Sourcery

Add WebP image support across image detection logic and file dialogs while aligning accepted extensions with existing image formats.

New Features:
- Allow selecting and saving .webp images in all relevant QFileDialog image and media pickers.
- Treat files with .webp, .gif, and .bmp extensions as images via the shared image extension helper.

Enhancements:
- Unify image type detection to rely on a shared extension list before falling back to mimetype checks.
- Extend global image file type filters to include .webp for consistency across the application.