### PR TITLE
feat: selectable GFPGAN model (1024 / 512) with hot-swap

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -70,6 +70,13 @@ enable_interpolation: bool = True # Toggle temporal smoothing
 interpolation_weight: float = 0  # Blend weight for current frame (0.0-1.0). Lower=smoother.
 # --- END: Added for Frame Interpolation ---
 
+# GFPGAN model filename. Currently shipped variants:
+#   gfpgan-1024.onnx  — 512 in, 1024 out (super-res head). Highest quality.
+#   GFPGANv1.4.onnx   — 512 in, 512 out. Lighter, faster.
+# Both files are hosted on the hacksider/deep-live-cam HF model repo.
+# Hot-swap supported via reset_face_enhancer() (called from UI on change).
+gfpgan_model_filename: str = "gfpgan-1024.onnx"
+
 # --- END OF FILE globals.py ---
 
 import threading

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -55,9 +55,9 @@ def reset_face_enhancer() -> None:
     global FACE_ENHANCER
     with THREAD_LOCK:
         FACE_ENHANCER = None
-    # Also invalidate the feathered-mask cache — output size will likely change
-    _enhancer_cache['mask'] = None
-    _enhancer_cache['mask_size'] = 0
+        # Also invalidate the feathered-mask cache — output size will likely change
+        _enhancer_cache['mask'] = None
+        _enhancer_cache['mask_size'] = 0
 
 
 def pre_check() -> bool:

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -42,12 +42,30 @@ FFHQ_TEMPLATE_512 = np.array(
 )
 
 
+def _gfpgan_model_path() -> str:
+    filename = getattr(modules.globals, "gfpgan_model_filename", "gfpgan-1024.onnx")
+    return os.path.join(models_dir, filename)
+
+
+def reset_face_enhancer() -> None:
+    """Drop the cached GFPGAN session so next call reloads with current
+    globals.gfpgan_model_filename. Called by the UI on enhancer dropdown
+    change so the user can hot-swap GFPGAN-1024 ⇄ GFPGAN-512 mid-session.
+    """
+    global FACE_ENHANCER
+    with THREAD_LOCK:
+        FACE_ENHANCER = None
+    # Also invalidate the feathered-mask cache — output size will likely change
+    _enhancer_cache['mask'] = None
+    _enhancer_cache['mask_size'] = 0
+
+
 def pre_check() -> bool:
-    model_path = os.path.join(models_dir, "gfpgan-1024.onnx")
+    model_path = _gfpgan_model_path()
     if not os.path.exists(model_path):
         update_status(
             f"GFPGAN ONNX model not found at {model_path}. "
-            "Please place gfpgan-1024.onnx in the models folder.",
+            f"Place {os.path.basename(model_path)} in the models folder.",
             NAME,
         )
         return False
@@ -72,7 +90,7 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
 
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
-            model_path = os.path.join(models_dir, "gfpgan-1024.onnx")
+            model_path = _gfpgan_model_path()
 
             if not os.path.exists(model_path):
                 raise FileNotFoundError(
@@ -84,6 +102,7 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
                     create_onnx_session,
                 )
 
+                print(f"{NAME}: Loading GFPGAN ONNX model from {model_path}")
                 FACE_ENHANCER = create_onnx_session(model_path)
 
                 input_info = FACE_ENHANCER.get_inputs()[0]

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -614,10 +614,12 @@ class MainWindow(QMainWindow):
         grid.addWidget(enhancer_label, len(items) // 2, 0)
 
         self.cb_enhancer = QComboBox()
-        self.cb_enhancer.addItems(["None", "GFPGAN", "GPEN-512", "GPEN-256"])
+        self.cb_enhancer.addItems(["None", "GFPGAN-1024", "GFPGAN-512", "GPEN-512", "GPEN-256"])
         initial = "None"
         if modules.globals.fp_ui.get("face_enhancer", False):
-            initial = "GFPGAN"
+            # Pick the GFPGAN variant currently selected via globals
+            fn = getattr(modules.globals, "gfpgan_model_filename", "gfpgan-1024.onnx")
+            initial = "GFPGAN-512" if fn == "GFPGANv1.4.onnx" else "GFPGAN-1024"
         elif modules.globals.fp_ui.get("face_enhancer_gpen512", False):
             initial = "GPEN-512"
         elif modules.globals.fp_ui.get("face_enhancer_gpen256", False):
@@ -817,17 +819,36 @@ class MainWindow(QMainWindow):
             close_mapper_window()
 
     def _on_enhancer_change(self, choice: str) -> None:
+        # Both GFPGAN variants use the same processor (face_enhancer) but
+        # differ in which ONNX model file is loaded.
         key_map = {
             "None": None,
-            "GFPGAN": "face_enhancer",
+            "GFPGAN-1024": "face_enhancer",
+            "GFPGAN-512": "face_enhancer",
             "GPEN-512": "face_enhancer_gpen512",
             "GPEN-256": "face_enhancer_gpen256",
         }
+        gfpgan_filename = {
+            "GFPGAN-1024": "gfpgan-1024.onnx",
+            "GFPGAN-512": "GFPGANv1.4.onnx",
+        }
+
         for key in ("face_enhancer", "face_enhancer_gpen256", "face_enhancer_gpen512"):
             _update_tumbler(key, False)
         selected = key_map.get(choice)
         if selected:
             _update_tumbler(selected, True)
+
+        # If user picked a GFPGAN variant, update the model filename and
+        # drop the cached session so the next inference reloads from disk.
+        if choice in gfpgan_filename:
+            prev = getattr(modules.globals, "gfpgan_model_filename", None)
+            modules.globals.gfpgan_model_filename = gfpgan_filename[choice]
+            if prev != gfpgan_filename[choice]:
+                from modules.processors.frame.face_enhancer import reset_face_enhancer
+                reset_face_enhancer()
+                update_status(f"GFPGAN model set to {gfpgan_filename[choice]}")
+
         save_switch_states()
 
     def _on_transparency_change(self, value: float) -> None:


### PR DESCRIPTION
## Summary

Lets the user pick between the two GFPGAN ONNX variants the project hosts via the existing Face Enhancer dropdown, and hot-swap between them without restarting. The single hardcoded `gfpgan-1024.onnx` load is replaced by a `globals.gfpgan_model_filename` lookup with `gfpgan-1024.onnx` as default (preserves current behavior).

## Why

The two GFPGAN ONNX models on the [hacksider/deep-live-cam HF repo](https://huggingface.co/hacksider/deep-live-cam/tree/main) have meaningfully different quality/speed trade-offs:

- **`gfpgan-1024.onnx`** (~365 MB) — 512 in / 1024 out (super-res head). Highest visual quality. Slower per call. Current default.
- **`GFPGANv1.4.onnx`** (~340 MB) — 512 in / 512 out. Standard GFPGAN 1.4 weights converted to ONNX. Lighter, faster.

Pre-PR there was no way to select the faster one without editing source. With both options exposed, users on lower-end GPUs (or USB-bandwidth-constrained webcams where the quality gain is invisible anyway) can pick the lighter model. Power users keep the 1024 head as default.

Both files are already hosted on the project's HF repo — no new external dependency, just an existing-but-unused asset becoming UI-selectable.

## What changed

- **`modules/globals.py`** — new `gfpgan_model_filename` global, defaults to `\"gfpgan-1024.onnx\"`. Comment notes both files are on the HF repo.
- **`modules/processors/frame/face_enhancer.py`**
  - `_gfpgan_model_path()` reads the global with a safe fallback.
  - `pre_check()` and `get_face_enhancer()` now use the helper instead of a hardcoded filename. Error message refers to the configured file.
  - New `reset_face_enhancer()` drops the cached ORT session and invalidates the feathered-mask cache so the next call reloads cleanly with the new model. Safe to call mid-session.
  - One-line log on session load (`Loading GFPGAN ONNX model from <path>`) so users can verify which variant is active — matches the existing GPEN-512 logging style.
- **`modules/ui.py`**
  - Enhancer dropdown options expanded:
    - Before: `[None, GFPGAN, GPEN-512, GPEN-256]`
    - After: `[None, GFPGAN-1024, GFPGAN-512, GPEN-512, GPEN-256]`
  - Initial value picks the variant matching the saved `gfpgan_model_filename`.
  - `_on_enhancer_change` maps both GFPGAN labels to the same `face_enhancer` processor key, sets the filename in globals, and calls `reset_face_enhancer()` only when the variant actually changed.

`enhance_face()` already auto-discovers the model's I/O shape from the ONNX session, so switching between 512-out and 1024-out is dimension-safe with no other code changes.

## Test plan

- [ ] Default state: launch with no prior settings → dropdown shows `GFPGAN-1024` when enhancer toggled on; behavior identical to pre-PR
- [ ] Place `GFPGANv1.4.onnx` from HF in `models/`, switch GFPGAN-1024 → GFPGAN-512 mid-session → console prints new model path, next swap uses 512-out
- [ ] Switch GFPGAN-512 → GFPGAN-1024 mid-session → reverse of above
- [ ] GPEN-512 / GPEN-256 paths unchanged from current behavior
- [ ] Missing `GFPGANv1.4.onnx` on disk → clear error referencing the missing filename (not the hardcoded 1024 message)

No new dependencies.