### PR TITLE
feat: capture resolution + detection size dropdowns

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -59,7 +59,7 @@ def parse_args() -> None:
     program.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
     program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=[suggest_default_execution_provider()], choices=suggest_execution_providers(), nargs='+')
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
-    program.add_argument('--det-size', help='face detection input size (160, 320, or 640)', dest='det_size', type=int, default=640, choices=[160, 320, 640])
+    program.add_argument('--det-size', help='face detection input size (160, 320, or 640)', dest='det_size', type=int, default=modules.globals.DEFAULT_DET_SIZE, choices=[160, 320, 640])
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
 
     # register deprecated args

--- a/modules/core.py
+++ b/modules/core.py
@@ -59,6 +59,7 @@ def parse_args() -> None:
     program.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
     program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=[suggest_default_execution_provider()], choices=suggest_execution_providers(), nargs='+')
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
+    program.add_argument('--det-size', help='face detection input size (160, 320, or 640)', dest='det_size', type=int, default=640, choices=[160, 320, 640])
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
 
     # register deprecated args
@@ -88,6 +89,7 @@ def parse_args() -> None:
     modules.globals.max_memory = args.max_memory
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
+    modules.globals.det_size = args.det_size
     modules.globals.lang = args.lang
 
     #for ENHANCER tumblers:

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -54,8 +54,9 @@ def get_face_analyser() -> Any:
                     providers=providers,
                     allowed_modules=['detection', 'recognition', 'landmark_2d_106']
                 )
-                analyser.prepare(ctx_id=0, det_size=_current_det_size())
-                _optimize_det_model(analyser, providers)
+                det_size = _current_det_size()
+                analyser.prepare(ctx_id=0, det_size=det_size)
+                _optimize_det_model(analyser, providers, det_size)
                 # Publish only after prepare()/optimize() complete, so a
                 # lock-free reader can never observe a half-built analyser
                 # (insightface fixes det shape at prepare() time).
@@ -65,7 +66,7 @@ def get_face_analyser() -> Any:
     return analyser
 
 
-def _optimize_det_model(fa: Any, providers) -> None:
+def _optimize_det_model(fa: Any, providers, det_size: tuple) -> None:
     """Replace the detection model's ONNX session with a CoreML-optimized one.
 
     Folds dynamic Shape→Gather chains into constants (the input size is
@@ -81,7 +82,7 @@ def _optimize_det_model(fa: Any, providers) -> None:
     if model_path is None or not os.path.exists(model_path):
         return
 
-    ds = _current_det_size()
+    ds = det_size
     input_shape = (1, 3, ds[1], ds[0])
     optimized_path = optimize_for_coreml(model_path, input_shape=input_shape)
     if optimized_path == model_path:

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -15,7 +15,22 @@ from pathlib import Path
 FACE_ANALYSER = None
 FACE_ANALYSER_LOCK = threading.Lock()
 
-DET_SIZE = (640, 640)
+
+def _current_det_size() -> tuple:
+    s = int(getattr(modules.globals, 'det_size', 640))
+    return (s, s)
+
+
+def reset_face_analyser() -> None:
+    """Force re-init on next get_face_analyser() call.
+
+    Called when det_size changes — insightface FaceAnalysis fixes its
+    detection input shape at prepare() time, so a new size requires a
+    fresh prepare() call.
+    """
+    global FACE_ANALYSER
+    with FACE_ANALYSER_LOCK:
+        FACE_ANALYSER = None
 
 
 def get_face_analyser() -> Any:
@@ -35,7 +50,7 @@ def get_face_analyser() -> Any:
                     providers=providers,
                     allowed_modules=['detection', 'recognition', 'landmark_2d_106']
                 )
-                FACE_ANALYSER.prepare(ctx_id=0, det_size=DET_SIZE)
+                FACE_ANALYSER.prepare(ctx_id=0, det_size=_current_det_size())
                 _optimize_det_model(FACE_ANALYSER, providers)
     return FACE_ANALYSER
 
@@ -56,7 +71,8 @@ def _optimize_det_model(fa: Any, providers) -> None:
     if model_path is None or not os.path.exists(model_path):
         return
 
-    input_shape = (1, 3, DET_SIZE[1], DET_SIZE[0])
+    ds = _current_det_size()
+    input_shape = (1, 3, ds[1], ds[0])
     optimized_path = optimize_for_coreml(model_path, input_shape=input_shape)
     if optimized_path == model_path:
         return

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -37,7 +37,11 @@ def get_face_analyser() -> Any:
     """Get face analyser with thread-safe initialization."""
     global FACE_ANALYSER
 
-    if FACE_ANALYSER is None:
+    # Snapshot the global so a concurrent reset_face_analyser() (e.g. a
+    # det_size change from the UI thread mid-Live) can't null it between our
+    # check and the return.
+    analyser = FACE_ANALYSER
+    if analyser is None:
         with FACE_ANALYSER_LOCK:
             # Double-check after acquiring lock
             if FACE_ANALYSER is None:
@@ -45,14 +49,20 @@ def get_face_analyser() -> Any:
                     build_provider_config,
                 )
                 providers = build_provider_config()
-                FACE_ANALYSER = insightface.app.FaceAnalysis(
+                analyser = insightface.app.FaceAnalysis(
                     name='buffalo_l',
                     providers=providers,
                     allowed_modules=['detection', 'recognition', 'landmark_2d_106']
                 )
-                FACE_ANALYSER.prepare(ctx_id=0, det_size=_current_det_size())
-                _optimize_det_model(FACE_ANALYSER, providers)
-    return FACE_ANALYSER
+                analyser.prepare(ctx_id=0, det_size=_current_det_size())
+                _optimize_det_model(analyser, providers)
+                # Publish only after prepare()/optimize() complete, so a
+                # lock-free reader can never observe a half-built analyser
+                # (insightface fixes det shape at prepare() time).
+                FACE_ANALYSER = analyser
+            else:
+                analyser = FACE_ANALYSER
+    return analyser
 
 
 def _optimize_det_model(fa: Any, providers) -> None:

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -17,7 +17,7 @@ FACE_ANALYSER_LOCK = threading.Lock()
 
 
 def _current_det_size() -> tuple:
-    s = int(getattr(modules.globals, 'det_size', 640))
+    s = int(getattr(modules.globals, 'det_size', modules.globals.DEFAULT_DET_SIZE))
     return (s, s)
 
 

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -70,6 +70,18 @@ enable_interpolation: bool = True # Toggle temporal smoothing
 interpolation_weight: float = 0  # Blend weight for current frame (0.0-1.0). Lower=smoother.
 # --- END: Added for Frame Interpolation ---
 
+# Face detection resolution (160, 320, or 640).
+# Lower = faster detection, fewer FLOPs, less accurate at distance.
+# Changes require face analyser re-init (handled in UI by clearing FACE_ANALYSER).
+det_size: int = 640
+
+# Webcam capture resolution requested via cv2.CAP_PROP_FRAME_WIDTH/HEIGHT.
+# Camera may negotiate to its nearest supported size — actual size is
+# printed in console as "[VideoCapturer] WxH @ FPS".
+# Default 640x480: native on virtually every webcam, fastest reliable mode
+# on USB 2.0. Higher 16:9 tiers (540/720/1080) selectable in UI.
+capture_resolution: tuple = (640, 480)
+
 # --- END OF FILE globals.py ---
 
 import threading

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -73,7 +73,10 @@ interpolation_weight: float = 0  # Blend weight for current frame (0.0-1.0). Low
 # Face detection resolution (160, 320, or 640).
 # Lower = faster detection, fewer FLOPs, less accurate at distance.
 # Changes require face analyser re-init (handled in UI by clearing FACE_ANALYSER).
-det_size: int = 640
+# DEFAULT_DET_SIZE is the single source of truth for the default — UI,
+# face_analyser, and CLI all reference it so they can't drift apart.
+DEFAULT_DET_SIZE: int = 640
+det_size: int = DEFAULT_DET_SIZE
 
 # Webcam capture resolution requested via cv2.CAP_PROP_FRAME_WIDTH/HEIGHT.
 # Camera may negotiate to its nearest supported size — actual size is

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -698,9 +698,12 @@ class MainWindow(QMainWindow):
 
     def _build_camera_card(self) -> QGroupBox:
         card = QGroupBox(_("Camera"))
-        layout = QHBoxLayout(card)
+        grid = QGridLayout(card)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(6)
 
-        layout.addWidget(QLabel(_("Select Camera:")))
+        # Row 0: camera selector + Live button
+        grid.addWidget(QLabel(_("Select Camera:")), 0, 0)
         self._camera_indices, self._camera_names = get_available_cameras()
 
         self.cb_camera = QComboBox()
@@ -712,15 +715,74 @@ class MainWindow(QMainWindow):
             self.cb_camera.addItems(self._camera_names)
             cam_ok = True
         self.cb_camera.setToolTip(_("Select which camera to use for live mode"))
-        layout.addWidget(self.cb_camera, 1)
+        grid.addWidget(self.cb_camera, 0, 1)
 
         self.btn_live = QPushButton(_("Live"))
         self.btn_live.setEnabled(cam_ok)
         self.btn_live.setToolTip(_("Start real-time face swap using webcam"))
         self.btn_live.clicked.connect(self._on_live)
-        layout.addWidget(self.btn_live)
+        grid.addWidget(self.btn_live, 0, 2)
 
+        # Row 1: capture resolution
+        grid.addWidget(QLabel(_("Resolution:")), 1, 0)
+        self.cb_resolution = QComboBox()
+        # 640x480 is native on virtually every webcam and the safest 30fps
+        # mode on USB 2.0. Higher tiers are 16:9 and useful when the camera
+        # supports them natively (DSLR + capture card, USB 3.0 webcams).
+        self._resolution_options = [
+            ("640 x 480", (640, 480)),
+            ("960 x 540 (qHD)", (960, 540)),
+            ("1280 x 720 (HD)", (1280, 720)),
+            ("1920 x 1080 (FHD)", (1920, 1080)),
+        ]
+        for label, _wh in self._resolution_options:
+            self.cb_resolution.addItem(label)
+        cur = tuple(modules.globals.capture_resolution)
+        idx = next((i for i, (_, wh) in enumerate(self._resolution_options) if wh == cur), 0)
+        self.cb_resolution.setCurrentIndex(idx)
+        self.cb_resolution.currentIndexChanged.connect(self._on_resolution_change)
+        self.cb_resolution.setToolTip(_(
+            "Requested webcam resolution. Camera may negotiate to its "
+            "nearest supported size — actual size printed in console as "
+            "'[VideoCapturer] WxH @ FPS'. Applies on next Live start.\n\n"
+            "640x480 is native on virtually every webcam and the safest "
+            "30fps choice. qHD often works too. HD/FHD typically drop to "
+            "~10fps on USB 2.0 webcams due to isochronous bandwidth limits."
+        ))
+        grid.addWidget(self.cb_resolution, 1, 1, 1, 2)
+
+        # Row 2: face detection size
+        grid.addWidget(QLabel(_("Det size:")), 2, 0)
+        self.cb_det_size = QComboBox()
+        self._det_size_options = [160, 320, 640]
+        for v in self._det_size_options:
+            self.cb_det_size.addItem(f"{v} x {v}")
+        cur_det = int(getattr(modules.globals, 'det_size', 640))
+        idx = self._det_size_options.index(cur_det) if cur_det in self._det_size_options else 2
+        self.cb_det_size.setCurrentIndex(idx)
+        self.cb_det_size.currentIndexChanged.connect(self._on_det_size_change)
+        self.cb_det_size.setToolTip(_(
+            "Face detection input resolution. Lower = faster, less accurate at "
+            "distance. Changes take effect on next face analyser init."
+        ))
+        grid.addWidget(self.cb_det_size, 2, 1, 1, 2)
+
+        grid.setColumnStretch(1, 1)
         return card
+
+    def _on_resolution_change(self, idx: int) -> None:
+        if 0 <= idx < len(self._resolution_options):
+            _label, wh = self._resolution_options[idx]
+            modules.globals.capture_resolution = wh
+            update_status(f"Capture resolution set to {wh[0]}x{wh[1]} (applies on next Live start)")
+
+    def _on_det_size_change(self, idx: int) -> None:
+        if 0 <= idx < len(self._det_size_options):
+            v = self._det_size_options[idx]
+            modules.globals.det_size = v
+            from modules.face_analyser import reset_face_analyser
+            reset_face_analyser()
+            update_status(f"Face detection size set to {v}x{v} (analyser will re-init on next call)")
 
     # ── slot handlers ────────────────────────────────────────────────────
 
@@ -1184,7 +1246,8 @@ class WebcamPreviewWindow(QWidget):
         layout.addWidget(self._image_label, 1)
 
         self._cap = VideoCapturer(camera_index)
-        if not self._cap.start(PREVIEW_DEFAULT_WIDTH, PREVIEW_DEFAULT_HEIGHT, 60):
+        req_w, req_h = modules.globals.capture_resolution
+        if not self._cap.start(req_w, req_h, 60):
             update_status("Failed to start camera")
             QTimer.singleShot(0, self.close)
             return

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -63,6 +63,7 @@ from modules.face_analyser import (
     get_unique_faces_from_target_image,
     get_unique_faces_from_target_video,
     has_valid_map,
+    reset_face_analyser,
     simplify_maps,
 )
 from modules.gettext import LanguageManager
@@ -314,6 +315,8 @@ def save_switch_states():
         "mouth_mask": modules.globals.mouth_mask,
         "show_mouth_mask_box": modules.globals.show_mouth_mask_box,
         "mouth_mask_size": modules.globals.mouth_mask_size,
+        "capture_resolution": list(modules.globals.capture_resolution),
+        "det_size": modules.globals.det_size,
     }
     try:
         with open("switch_states.json", "w") as f:
@@ -343,6 +346,16 @@ def load_switch_states():
         modules.globals.mouth_mask_size = 0.0
         modules.globals.mouth_mask = False
         modules.globals.show_mouth_mask_box = False
+        # Validate persisted camera settings before trusting them — a hand-
+        # edited/corrupt file shouldn't push a bad size into cv2/insightface.
+        res = state.get("capture_resolution")
+        if isinstance(res, (list, tuple)) and len(res) == 2:
+            try:
+                modules.globals.capture_resolution = (int(res[0]), int(res[1]))
+            except (TypeError, ValueError):
+                pass
+        if state.get("det_size") in (160, 320, 640):
+            modules.globals.det_size = int(state["det_size"])
     except FileNotFoundError:
         pass
     except (OSError, json.JSONDecodeError):
@@ -774,15 +787,25 @@ class MainWindow(QMainWindow):
         if 0 <= idx < len(self._resolution_options):
             _label, wh = self._resolution_options[idx]
             modules.globals.capture_resolution = wh
-            update_status(f"Capture resolution set to {wh[0]}x{wh[1]} (applies on next Live start)")
+            save_switch_states()
+            # Pre-translate the static template; append the dynamic size after
+            # so the message still participates in localization (update_status
+            # only translates whole-string keys).
+            update_status(
+                _("Capture resolution set (applies on next Live start):")
+                + f" {wh[0]}x{wh[1]}"
+            )
 
     def _on_det_size_change(self, idx: int) -> None:
         if 0 <= idx < len(self._det_size_options):
             v = self._det_size_options[idx]
             modules.globals.det_size = v
-            from modules.face_analyser import reset_face_analyser
             reset_face_analyser()
-            update_status(f"Face detection size set to {v}x{v} (analyser will re-init on next call)")
+            save_switch_states()
+            update_status(
+                _("Face detection size set (analyser re-inits on next call):")
+                + f" {v}x{v}"
+            )
 
     # ── slot handlers ────────────────────────────────────────────────────
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -757,8 +757,8 @@ class MainWindow(QMainWindow):
         self._det_size_options = [160, 320, 640]
         for v in self._det_size_options:
             self.cb_det_size.addItem(f"{v} x {v}")
-        cur_det = int(getattr(modules.globals, 'det_size', 640))
-        idx = self._det_size_options.index(cur_det) if cur_det in self._det_size_options else 2
+        cur_det = int(getattr(modules.globals, 'det_size', modules.globals.DEFAULT_DET_SIZE))
+        idx = self._det_size_options.index(cur_det) if cur_det in self._det_size_options else self._det_size_options.index(modules.globals.DEFAULT_DET_SIZE)
         self.cb_det_size.setCurrentIndex(idx)
         self.cb_det_size.currentIndexChanged.connect(self._on_det_size_change)
         self.cb_det_size.setToolTip(_(

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -351,7 +351,9 @@ def load_switch_states():
         res = state.get("capture_resolution")
         if isinstance(res, (list, tuple)) and len(res) == 2:
             try:
-                modules.globals.capture_resolution = (int(res[0]), int(res[1]))
+                w, h = int(res[0]), int(res[1])
+                if w > 0 and h > 0:
+                    modules.globals.capture_resolution = (w, h)
             except (TypeError, ValueError):
                 pass
         if state.get("det_size") in (160, 320, 640):
@@ -771,7 +773,14 @@ class MainWindow(QMainWindow):
         for v in self._det_size_options:
             self.cb_det_size.addItem(f"{v} x {v}")
         cur_det = int(getattr(modules.globals, 'det_size', modules.globals.DEFAULT_DET_SIZE))
-        idx = self._det_size_options.index(cur_det) if cur_det in self._det_size_options else self._det_size_options.index(modules.globals.DEFAULT_DET_SIZE)
+        # Normalize to a valid option first so .index() can never raise: fall back
+        # to the default size, then to the last (highest) option if even that is
+        # somehow missing.
+        if cur_det not in self._det_size_options:
+            cur_det = (modules.globals.DEFAULT_DET_SIZE
+                       if modules.globals.DEFAULT_DET_SIZE in self._det_size_options
+                       else self._det_size_options[-1])
+        idx = self._det_size_options.index(cur_det)
         self.cb_det_size.setCurrentIndex(idx)
         self.cb_det_size.currentIndexChanged.connect(self._on_det_size_change)
         self.cb_det_size.setToolTip(_(


### PR DESCRIPTION
## Summary

Adds two dropdowns to the Camera card on the main window:

- **Resolution** — requested webcam capture size (640×480 / 960×540 / 1280×720 / 1920×1080). Applied on next Live start.
- **Det size** — face detection input size (160 / 320 / 640). Triggers face analyser re-init so the change takes effect immediately.

Also exposes `--det-size` as a CLI flag for headless runs.

## Why

**Resolution:** Previously `VideoCapturer.start()` was hardcoded to `PREVIEW_DEFAULT_WIDTH/HEIGHT` which mixes \"the preview window's pixel size\" with \"the camera's capture resolution\" — they're separate concerns. With this PR they're decoupled and the capture side becomes user-configurable.

Why these choices specifically: 640×480 is native on virtually every USB 2.0 webcam and the safest 30fps mode (USB 2.0 isochronous bandwidth caps ~30fps on common YUYV at this size). Higher tiers are useful for users with capture cards or USB 3.0 webcams; the tooltip explains that 720p+ typically drops to ~10fps over USB 2.0 due to bandwidth, so users know what they're trading.

**Det size:** `insightface` defaults to 640×640 detection which is plenty accurate but expensive per frame. At 320 or 160 the detector runs much faster — a meaningful speedup when the face is large in frame (live webcam usage), with negligible accuracy loss for that distance regime. Currently the only way to change `det_size` is by editing the source.

## What changed

- **`modules/globals.py`**
  - New `det_size: int = 640` and `capture_resolution: tuple = (640, 480)` globals with documentation.
- **`modules/face_analyser.py`**
  - The hardcoded `DET_SIZE = (640, 640)` constant is replaced by `_current_det_size()` that reads `modules.globals.det_size` per call.
  - New `reset_face_analyser()` clears the cached `FACE_ANALYSER` so the next call re-prepares insightface with the new size.
- **`modules/core.py`** — new `--det-size` argparse flag with `choices=[160, 320, 640]` for headless runs.
- **`modules/ui.py`**
  - Camera card now uses a `QGridLayout` (was a single row) with the two new dropdowns on rows 1 and 2 below the camera selector + Live button.
  - `_on_resolution_change` writes the selected `(w, h)` tuple to `modules.globals.capture_resolution`.
  - `_on_det_size_change` writes the selected `int` and calls `reset_face_analyser()` so the new size kicks in on the next analyser call.
  - `WebcamPreviewWindow` reads `modules.globals.capture_resolution` instead of `PREVIEW_DEFAULT_WIDTH/HEIGHT` (the constants still drive preview-window sizing, separate concern).

## Test plan

- [ ] Defaults: launch, Camera card shows Resolution=`640x480` and Det size=`640 x 640`. Live mode behaves as before
- [ ] Switch Resolution to `1280 x 720`, start Live → console shows `[VideoCapturer] 1280x720` or the camera's nearest supported size
- [ ] Switch Det size from 640 → 320 while no Live is running → next face-analysis call (e.g. starting Live with map_faces) uses the new size
- [ ] Switch Det size mid-Live → analyser re-inits on the next frame; no crash
- [ ] `python run.py --det-size 320` headless honors the flag

No new dependencies.

## Summary by Sourcery

Add configurable camera capture resolution and face detection size for both GUI and headless live mode.

New Features:
- Introduce Resolution dropdown in the Camera card to choose webcam capture size for live mode.
- Introduce Det size dropdown in the Camera card to configure face detection input resolution and reinitialize the analyser on change.
- Expose a --det-size CLI flag to control face detection input size in headless runs.

Enhancements:
- Make the face analyser read a configurable global det_size and allow forcing a re-init when it changes.
- Have the webcam preview use the global capture_resolution instead of hardcoded preview dimensions.