### PR TITLE
feat: virtual camera output (pyvirtualcam → OBS Virtual Camera)

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -70,6 +70,13 @@ enable_interpolation: bool = True # Toggle temporal smoothing
 interpolation_weight: float = 0  # Blend weight for current frame (0.0-1.0). Lower=smoother.
 # --- END: Added for Frame Interpolation ---
 
+# Virtual camera output (pyvirtualcam → OBS Virtual Camera driver).
+# When enabled, processed frames are upscaled to 1280x720 and sent to the
+# virtual cam so apps like Discord/Meet/Zoom can pick them up as a
+# webcam. Requires OBS Studio installed (for the driver). Toggle is
+# read at Live-start; mid-Live toggling requires Stop+Start.
+virtual_cam: bool = False
+
 # --- END OF FILE globals.py ---
 
 import threading

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -91,6 +91,40 @@ PREVIEW_MAX_WIDTH = 1200
 PREVIEW_DEFAULT_WIDTH = 640
 PREVIEW_DEFAULT_HEIGHT = 360
 
+# Virtual camera output size — fixed 720p so meeting apps don't see
+# our capture-resolution variations. Frames are upscaled before send.
+VCAM_W, VCAM_H = 1280, 720
+VCAM_FPS = 30
+
+
+def _aspect_crop_to(frame, out_w: int, out_h: int):
+    """Center-crop ``frame`` to the (out_w, out_h) aspect ratio, then resize.
+
+    Used by the vcam send path. A plain ``cv2.resize`` to a different
+    aspect (e.g. 4:3 -> 16:9) horizontally squashes faces in meeting
+    apps. Cropping the longer axis first keeps faces correctly
+    proportioned at the cost of trimming a bit off top/bottom (for
+    4:3 input -> 16:9 output) or left/right (for ultra-wide input).
+    """
+    h, w = frame.shape[:2]
+    if w <= 0 or h <= 0:
+        return frame
+    in_aspect = w / h
+    out_aspect = out_w / out_h
+    if abs(in_aspect - out_aspect) < 0.01:
+        cropped = frame
+    elif in_aspect < out_aspect:
+        new_h = max(1, int(round(w / out_aspect)))
+        y0 = max(0, (h - new_h) // 2)
+        cropped = frame[y0:y0 + new_h, :, :]
+    else:
+        new_w = max(1, int(round(h * out_aspect)))
+        x0 = max(0, (w - new_w) // 2)
+        cropped = frame[:, x0:x0 + new_w, :]
+    if cropped.shape[1] == out_w and cropped.shape[0] == out_h:
+        return cropped
+    return cv2.resize(cropped, (out_w, out_h), interpolation=cv2.INTER_LINEAR)
+
 POPUP_WIDTH = 750
 POPUP_HEIGHT = 810
 POPUP_SCROLL_WIDTH = 720
@@ -593,6 +627,10 @@ class MainWindow(QMainWindow):
                                  "Fix blue/green color cast from some webcams")
         self.sw_show_fps = make("show_fps", "Show FPS",
                                 "Display frames-per-second counter on the live preview")
+        self.sw_virtual_cam = make("virtual_cam", "Virtual Cam",
+                                   "Output processed frames to OBS Virtual Camera (1280x720) "
+                                   "so Discord/Meet/Zoom can pick it up. Requires OBS Studio "
+                                   "installed for the driver. Applied at next Live start.")
 
         # Map faces is special — closes mapper when toggled off.
         self.sw_map_faces = _Switch(_("Map faces"), modules.globals.map_faces,
@@ -605,6 +643,7 @@ class MainWindow(QMainWindow):
             self.sw_keep_frames, self.sw_many_faces,
             self.sw_map_faces, self.sw_show_fps,
             self.sw_poisson, self.sw_color_fix,
+            self.sw_virtual_cam,
         ]
         for i, w in enumerate(items):
             grid.addWidget(w, i // 2, i % 2)
@@ -1198,6 +1237,41 @@ class WebcamPreviewWindow(QWidget):
         self._processed_queue: queue.Queue = queue.Queue(maxsize=2)
         self._stop_event = threading.Event()
 
+        # Optional virtual camera output (pyvirtualcam → OBS Virtual Camera).
+        # Snapshot the global at start so toggling mid-session doesn't crash
+        # the send loop; user must Stop+Start to change vcam state.
+        self._vcam = None
+        if getattr(modules.globals, "virtual_cam", False):
+            try:
+                import pyvirtualcam
+                self._vcam = pyvirtualcam.Camera(
+                    width=VCAM_W, height=VCAM_H, fps=VCAM_FPS
+                )
+                update_status(
+                    f"Virtual camera started: {self._vcam.device} @ {VCAM_W}x{VCAM_H}"
+                )
+            except ImportError:
+                update_status("pyvirtualcam not installed — pip install pyvirtualcam")
+                self._vcam = None
+            except Exception as e:
+                update_status(
+                    f"Virtual camera failed: {e}. Install OBS Studio for the OBS Virtual Camera driver."
+                )
+                self._vcam = None
+
+        # In vcam mode, replace the live preview with a static status
+        # message and shrink the window. Saves the cv2.resize + Qt repaint
+        # each tick, but keeps the window's X button as the stop control —
+        # same UX as the regular Live close flow.
+        if self._vcam is not None:
+            self.setWindowTitle("Virtual Cam — Live")
+            self.resize(360, 140)
+            self._image_label.setText(
+                "Virtual Cam is sending frames\nto OBS Virtual Camera.\n\n"
+                "Close this window to stop."
+            )
+            self._image_label.setStyleSheet("font-size: 14px; padding: 12px;")
+
         self._capture_worker = _CaptureWorker(
             self._cap, self._capture_queue, self._stop_event
         )
@@ -1221,8 +1295,33 @@ class WebcamPreviewWindow(QWidget):
             bgr_frame = self._processed_queue.get_nowait()
         except queue.Empty:
             return
-        bgr_frame = fit_image_to_size(bgr_frame, self.width(), self.height())
-        self._image_label.setPixmap(_bgr_to_qpixmap(bgr_frame))
+
+        # Send to virtual camera BEFORE the display fit-resize so meeting
+        # apps always see the full processed frame at a stable 1280x720,
+        # regardless of how the user has resized the preview window.
+        # Aspect-preserving center crop: many webcams negotiate 4:3 even
+        # when 16:9 is requested (e.g. 360p -> 480p). A plain resize to
+        # 1280x720 would horizontally squash that 4:3 frame, so we crop
+        # the longer axis to match the 16:9 output ratio first.
+        if self._vcam is not None:
+            try:
+                vcam_frame = _aspect_crop_to(bgr_frame, VCAM_W, VCAM_H)
+                rgb = cv2.cvtColor(vcam_frame, cv2.COLOR_BGR2RGB)
+                self._vcam.send(rgb)
+            except Exception as e:
+                # Don't kill the preview if vcam misbehaves — just log once.
+                if not getattr(self, "_vcam_warned", False):
+                    print(f"[vcam] send error (continuing without vcam): {e}")
+                    self._vcam_warned = True
+                self._vcam = None
+
+        # Skip the display-side resize + Qt pixmap conversion when in
+        # vcam mode (the label shows a static status string instead of
+        # the live preview). Saves the cv2.resize and the BGR→QImage
+        # copy each tick.
+        if self._vcam is None:
+            bgr_frame = fit_image_to_size(bgr_frame, self.width(), self.height())
+            self._image_label.setPixmap(_bgr_to_qpixmap(bgr_frame))
 
     def closeEvent(self, event) -> None:
         self._stop_event.set()
@@ -1239,6 +1338,12 @@ class WebcamPreviewWindow(QWidget):
             self._cap.release()
         except Exception:
             pass
+        if getattr(self, "_vcam", None) is not None:
+            try:
+                self._vcam.close()
+            except Exception:
+                pass
+            self._vcam = None
         global _WEBCAM_PREVIEW
         if _WEBCAM_PREVIEW is self:
             _WEBCAM_PREVIEW = None

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -116,11 +116,11 @@ def _aspect_crop_to(frame, out_w: int, out_h: int):
     elif in_aspect < out_aspect:
         new_h = max(1, int(round(w / out_aspect)))
         y0 = max(0, (h - new_h) // 2)
-        cropped = frame[y0:y0 + new_h, :, :]
+        cropped = frame[y0:y0 + new_h, :]
     else:
         new_w = max(1, int(round(h * out_aspect)))
         x0 = max(0, (w - new_w) // 2)
-        cropped = frame[:, x0:x0 + new_w, :]
+        cropped = frame[:, x0:x0 + new_w]
     if cropped.shape[1] == out_w and cropped.shape[0] == out_h:
         return cropped
     return cv2.resize(cropped, (out_w, out_h), interpolation=cv2.INTER_LINEAR)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ tensorflow>=2.15.0; sys_platform == 'darwin' and python_version < '3.13'
 opennsfw2==0.10.2
 protobuf==4.25.1
 pygrabber; sys_platform == 'win32'
+pyvirtualcam>=0.15.0
+# Note: pyvirtualcam needs OBS Studio installed on the host for the OBS
+# Virtual Camera driver. The pip package alone won't expose a virtual cam.


### PR DESCRIPTION
## Summary

Adds a **Virtual Cam** toggle in the Options card. When enabled at Live start, processed frames are sent to a virtual webcam (OBS Virtual Camera driver / `v4l2loopback` / OBS Virtual Camera on macOS) so apps like Discord, Zoom, Google Meet, Teams pick the swapped face up as a webcam input.

Output is fixed at 1280×720 / 30fps so meeting apps see a stable size regardless of the underlying capture resolution.

## Why

Right now the swapped output is preview-window only — useful for demos but not for the workflow most people actually want (looking like someone else on a video call). Every other consumer-facing face-swap project has a vcam-out path; this brings parity at minimal cost.

`pyvirtualcam` is the right dependency: it's the de-facto Python bridge to the OBS Virtual Camera driver (Windows + macOS) and `v4l2loopback` (Linux). Adding it is a few hundred KB; users still need to install OBS Studio for the driver itself, documented in the tooltip and the failure-path status messages.

## What changed

- **`requirements.txt`** — `pyvirtualcam>=0.15.0`
- **`modules/globals.py`** — `virtual_cam: bool = False` with a comment explaining the activation semantics
- **`modules/ui.py`**
  - `VCAM_W, VCAM_H = 1280, 720` and `VCAM_FPS = 30` module-level constants
  - `_aspect_crop_to(frame, w, h)` helper — center-crops to the target aspect before resize. Many webcams negotiate 4:3 (e.g. 640×480) even when asked for 16:9, and a bare resize to 1280×720 horizontally stretches faces. The crop trims top/bottom of 4:3 input so the face stays correctly proportioned in the meeting app. No-op fast path when input is already the right aspect / exact size.
  - `WebcamPreviewWindow.__init__` — after camera + worker setup:
    - Try `pyvirtualcam.Camera(width=VCAM_W, height=VCAM_H, fps=VCAM_FPS)`
    - On `ImportError` → status message instructing `pip install pyvirtualcam`
    - On any other `Exception` → status message instructing OBS Studio install (covers \"driver not registered\" cases)
    - On success → window is shrunk to 360×140 and the preview QLabel shows a static status string (\"Virtual Cam is sending frames to OBS Virtual Camera. Close this window to stop.\"). Saves the per-tick `cv2.resize` + Qt repaint when nobody's looking at the preview anyway.
  - `_tick()`:
    - Sends each processed frame to vcam BEFORE the display fit-resize, so meeting apps always see a stable 1280×720 regardless of preview window state
    - One-time warn on send error then silently disables vcam — preview loop survives transient driver issues
    - Skips display label update entirely when vcam is active
  - `closeEvent()` releases the vcam alongside the camera and workers
  - New `Virtual Cam` checkbox in the Options card wired to `globals.virtual_cam`

## Test plan

- [ ] OBS Studio not installed → toggle Virtual Cam → Live → status bar shows the OBS-install hint; preview behaves normally (no vcam)
- [ ] `pyvirtualcam` not installed → toggle Virtual Cam → Live → status bar shows the pip-install hint; preview behaves normally
- [ ] OBS installed, `pyvirtualcam` installed, toggle on, Live → small status window opens (no live preview), \"OBS Virtual Camera\" appears as a webcam in Discord / Meet / Zoom
- [ ] 640×480 capture (4:3) → meeting app sees correctly-proportioned face at 1280×720 (no horizontal squash). Confirms `_aspect_crop_to` is doing its job.
- [ ] Close the status window via X → vcam stops, camera + workers stop, meeting app loses the input cleanly
- [ ] Toggle off, restart Live → normal full-size preview window returns

## Platform notes

- **Windows:** Requires OBS Studio installed (provides the OBS Virtual Camera driver). Tested working.
- **Linux:** Should work with `v4l2loopback` kernel module. Untested.
- **macOS:** Should work with OBS Studio's virtual camera. Untested.

No new bundled binaries; the `pyvirtualcam` wheel is pure-Python with a small C extension already cross-compiled by upstream.

## Summary by Sourcery

Add optional virtual camera output so processed frames can be streamed to OBS Virtual Camera at a fixed 1280x720/30fps instead of only showing them in the preview window.

New Features:
- Introduce a Virtual Cam option that, when enabled, streams processed frames to an OBS-compatible virtual camera device at 1280x720 and 30fps.

Enhancements:
- Center-crop and resize frames to preserve aspect ratio before sending them to the virtual camera, avoiding distorted output in meeting apps.
- Adjust the live preview window to show a static status message and reduced size when virtual camera mode is active, skipping unnecessary per-frame preview updates.
- Ensure the virtual camera lifecycle is tied to the live window, including graceful startup, error reporting, and cleanup on close.

Build:
- Add pyvirtualcam>=0.15.0 as a dependency for virtual camera output, noting the requirement for an external OBS Virtual Camera driver.