### PR TITLE
Fix: resolve 4 confirmed bugs across modules

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -11,8 +11,8 @@ def imwrite_unicode(path, img, params=None):
     root, ext = os.path.splitext(path)
     if not ext:
         ext = ".png"
-        result, encoded_img = cv2.imencode(ext, img, params if params else [])
-        result, encoded_img = cv2.imencode(f".{ext}", img, params if params is not None else [])
-        encoded_img.tofile(path)
-        return True
-    return False
+    result, encoded_img = cv2.imencode(ext, img, params if params is not None else [])
+    if not result:
+        return False
+    encoded_img.tofile(path)
+    return True

--- a/modules/core.py
+++ b/modules/core.py
@@ -171,8 +171,6 @@ def limit_resources() -> None:
     # limit memory usage
     if modules.globals.max_memory:
         memory = modules.globals.max_memory * 1024 ** 3
-        if platform.system().lower() == 'darwin':
-            memory = modules.globals.max_memory * 1024 ** 6
         if platform.system().lower() == 'windows':
             import ctypes
             kernel32 = ctypes.windll.kernel32

--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -257,6 +257,8 @@ def get_unique_faces_from_target_image() -> Any:
         modules.globals.source_target_map = []
         target_frame = cv2.imread(modules.globals.target_path)
         many_faces = get_many_faces(target_frame)
+        if many_faces is None:
+            return None
         i = 0
 
         for face in many_faces:
@@ -291,6 +293,8 @@ def get_unique_faces_from_target_video() -> Any:
         for temp_frame_path in tqdm(temp_frame_paths, desc="Extracting face embeddings from frames"):
             temp_frame = cv2.imread(temp_frame_path)
             many_faces = get_many_faces(temp_frame)
+            if many_faces is None:
+                continue
 
             for face in many_faces:
                 face_embeddings.append(face.normed_embedding)

--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -37,6 +37,7 @@ def load_frame_processor_module(frame_processor: str) -> Any:
         frame_processor_module = importlib.import_module(f'modules.processors.frame.{frame_processor}')
         for method_name in FRAME_PROCESSORS_INTERFACE:
             if not hasattr(frame_processor_module, method_name):
+                print(f"Frame processor {frame_processor} is missing required method {method_name}")
                 sys.exit()
     except ImportError:
         print(f"Frame processor {frame_processor} not found")


### PR DESCRIPTION
## Summary

This PR fixes 4 confirmed bugs found during a full code audit.

## Changes

### 1. Fix imwrite_unicode returning False for files with extensions (Fixes #1841)
**File:** modules/__init__.py

The function had inverted logic: os.path.splitext('file.jpg') returns ext='.jpg' (truthy), so \if not ext:\ was False, causing the function to return False without writing. Also removed duplicate cv2.imencode call.

### 2. Fix macOS memory limit using wrong multiplier (Fixes #1839)
**File:** modules/core.py

1024 ** 6 produced ~4 exabytes instead of ~4 gigabytes. Removed the redundant macOS branch.

### 3. Fix crash when get_many_faces() returns None (Fixes #1840)
**File:** modules/face_analyser.py

get_many_faces() can return None on IndexError, but callers iterated without a None check. Added guards in get_unique_faces_from_target_image() and get_unique_faces_from_target_video().

### 4. Fix silent sys.exit() in load_frame_processor_module (Fixes #1843)
**File:** modules/processors/frame/core.py

Added error message before sys.exit() when a module lacks an interface method.

All 4 bugs were verified with test scripts before making changes.

## Summary by Sourcery

Fix multiple runtime bugs across image writing, face analysis, resource limiting, and frame processor loading.

Bug Fixes:
- Ensure imwrite_unicode correctly writes files with extensions and returns False only when encoding fails.
- Prevent crashes in unique face extraction when get_many_faces returns None for images or video frames.
- Use the correct memory multiplier for macOS by removing the erroneous platform-specific branch that set an excessively large limit.
- Emit a clear error message before exiting when a frame processor module is missing required interface methods.