### PR TITLE
feat: virtual camera output (pyvirtualcam → OBS Virtual Camera)

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -70,6 +70,13 @@ enable_interpolation: bool = True # Toggle temporal smoothing
 interpolation_weight: float = 0  # Blend weight for current frame (0.0-1.0). Lower=smoother.
 # --- END: Added for Frame Interpolation ---
 
+# Virtual camera output (pyvirtualcam → OBS Virtual Camera driver).
+# When enabled, processed frames are upscaled to VCAM 1280x720 and sent to
+# the virtual cam so apps like Discord/Meet/Zoom can pick it up as a
+# webcam. Requires OBS Studio installed (for the driver). Toggle is
+# read at Live-start; mid-Live toggling currently requires Stop+Start.
+virtual_cam: bool = False
+
 # --- END OF FILE globals.py ---
 
 import threading

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -610,8 +610,6 @@ class MainWindow(QMainWindow):
 
             def _on_toggle(v, f=field):
                 setattr(modules.globals, f, v)
-                if f == "virtual_cam":
-                    print(f"[vcam] toggle -> globals.virtual_cam = {v}")
                 save_switch_states()
 
             sw.toggled.connect(_on_toggle)
@@ -1216,8 +1214,9 @@ class _ProcessingWorker(QThread):
 
 
 class WebcamPreviewWindow(QWidget):
-    def __init__(self, camera_index: int):
+    def __init__(self, camera_index: int, on_close: Optional[Callable[[], None]] = None):
         super().__init__()
+        self._on_close_callback = on_close
         self.setWindowTitle("Live Preview")
         self.resize(PREVIEW_DEFAULT_WIDTH, PREVIEW_DEFAULT_HEIGHT)
         layout = QVBoxLayout(self)
@@ -1249,7 +1248,6 @@ class WebcamPreviewWindow(QWidget):
         self._vcam = None
         self._vcam_last_send_ts = 0.0
         vcam_requested = getattr(modules.globals, "virtual_cam", False)
-        print(f"[vcam] Live start — virtual_cam global = {vcam_requested}")
         if vcam_requested:
             try:
                 import pyvirtualcam
@@ -1370,21 +1368,19 @@ class WebcamPreviewWindow(QWidget):
             _WEBCAM_PREVIEW = None
         # Notify whoever opened us (typically MainWindow) so they can
         # reset their button state regardless of how we got closed.
-        cb = getattr(self, "_on_close_callback", None)
-        if cb is not None:
+        if self._on_close_callback is not None:
             try:
-                cb()
+                self._on_close_callback()
             except Exception as e:
-                print(f"[live] on_close callback raised: {e}")
+                update_status(f"Live close callback error: {e}")
         event.accept()
 
 
-def _open_webcam_preview(camera_index: int, on_close=None) -> None:
+def _open_webcam_preview(camera_index: int, on_close: Optional[Callable[[], None]] = None) -> None:
     global _WEBCAM_PREVIEW
     if _WEBCAM_PREVIEW is not None:
         _WEBCAM_PREVIEW.close()
-    _WEBCAM_PREVIEW = WebcamPreviewWindow(camera_index)
-    _WEBCAM_PREVIEW._on_close_callback = on_close
+    _WEBCAM_PREVIEW = WebcamPreviewWindow(camera_index, on_close=on_close)
     _WEBCAM_PREVIEW.show()
 
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -91,6 +91,40 @@ PREVIEW_MAX_WIDTH = 1200
 PREVIEW_DEFAULT_WIDTH = 640
 PREVIEW_DEFAULT_HEIGHT = 360
 
+# Virtual camera output size — fixed 720p so meeting apps don't see
+# our capture-resolution variations. Frames are upscaled before send.
+VCAM_W, VCAM_H = 1280, 720
+VCAM_FPS = 30
+
+
+def _aspect_crop_to(frame, out_w: int, out_h: int):
+    """Center-crop ``frame`` to the (out_w, out_h) aspect ratio, then resize.
+
+    Used by the vcam send path. A plain ``cv2.resize`` to a different
+    aspect (e.g. 4:3 -> 16:9) horizontally squashes faces in meeting
+    apps. Cropping the longer axis first keeps faces correctly
+    proportioned at the cost of trimming a bit off top/bottom (for
+    4:3 input -> 16:9 output) or left/right (for ultra-wide input).
+    """
+    h, w = frame.shape[:2]
+    if w <= 0 or h <= 0:
+        return frame
+    in_aspect = w / h
+    out_aspect = out_w / out_h
+    if abs(in_aspect - out_aspect) < 0.01:
+        cropped = frame
+    elif in_aspect < out_aspect:
+        new_h = max(1, int(round(w / out_aspect)))
+        y0 = max(0, (h - new_h) // 2)
+        cropped = frame[y0:y0 + new_h, :]
+    else:
+        new_w = max(1, int(round(h * out_aspect)))
+        x0 = max(0, (w - new_w) // 2)
+        cropped = frame[:, x0:x0 + new_w]
+    if cropped.shape[1] == out_w and cropped.shape[0] == out_h:
+        return cropped
+    return cv2.resize(cropped, (out_w, out_h), interpolation=cv2.INTER_LINEAR)
+
 POPUP_WIDTH = 750
 POPUP_HEIGHT = 810
 POPUP_SCROLL_WIDTH = 720
@@ -313,6 +347,7 @@ def save_switch_states():
         "mouth_mask": modules.globals.mouth_mask,
         "show_mouth_mask_box": modules.globals.show_mouth_mask_box,
         "mouth_mask_size": modules.globals.mouth_mask_size,
+        "virtual_cam": modules.globals.virtual_cam,
     }
     try:
         with open("switch_states.json", "w") as f:
@@ -342,6 +377,7 @@ def load_switch_states():
         modules.globals.mouth_mask_size = 0.0
         modules.globals.mouth_mask = False
         modules.globals.show_mouth_mask_box = False
+        modules.globals.virtual_cam = state.get("virtual_cam", False)
     except FileNotFoundError:
         pass
     except (OSError, json.JSONDecodeError):
@@ -571,12 +607,14 @@ class MainWindow(QMainWindow):
 
         def make(field, label, tip):
             sw = _Switch(_(label), getattr(modules.globals, field), _(tip))
-            sw.toggled.connect(
-                lambda v, f=field: (
-                    setattr(modules.globals, f, v),
-                    save_switch_states(),
-                )
-            )
+
+            def _on_toggle(v, f=field):
+                setattr(modules.globals, f, v)
+                if f == "virtual_cam":
+                    print(f"[vcam] toggle -> globals.virtual_cam = {v}")
+                save_switch_states()
+
+            sw.toggled.connect(_on_toggle)
             return sw
 
         self.sw_keep_fps = make("keep_fps", "Keep fps",
@@ -593,6 +631,10 @@ class MainWindow(QMainWindow):
                                  "Fix blue/green color cast from some webcams")
         self.sw_show_fps = make("show_fps", "Show FPS",
                                 "Display frames-per-second counter on the live preview")
+        self.sw_virtual_cam = make("virtual_cam", "Virtual Cam",
+                                   "Output processed frames to OBS Virtual Camera (1280x720) "
+                                   "so Discord/Meet/Zoom can pick it up. Requires OBS Studio "
+                                   "installed for the driver. Applied at next Live start.")
 
         # Map faces is special — closes mapper when toggled off.
         self.sw_map_faces = _Switch(_("Map faces"), modules.globals.map_faces,
@@ -605,13 +647,16 @@ class MainWindow(QMainWindow):
             self.sw_keep_frames, self.sw_many_faces,
             self.sw_map_faces, self.sw_show_fps,
             self.sw_poisson, self.sw_color_fix,
+            self.sw_virtual_cam,
         ]
         for i, w in enumerate(items):
             grid.addWidget(w, i // 2, i % 2)
 
-        # Face enhancer dropdown
+        # Face enhancer dropdown — place on the next free row.
+        # Items occupy ceil(len/2) rows; (len + 1) // 2 is the next row.
+        enhancer_row = (len(items) + 1) // 2
         enhancer_label = QLabel(_("Face Enhancer:"))
-        grid.addWidget(enhancer_label, len(items) // 2, 0)
+        grid.addWidget(enhancer_label, enhancer_row, 0)
 
         self.cb_enhancer = QComboBox()
         self.cb_enhancer.addItems(["None", "GFPGAN", "GPEN-512", "GPEN-256"])
@@ -625,7 +670,7 @@ class MainWindow(QMainWindow):
         self.cb_enhancer.setCurrentText(initial)
         self.cb_enhancer.currentTextChanged.connect(self._on_enhancer_change)
         self.cb_enhancer.setToolTip(_("Select a face enhancement model (None = no enhancement)"))
-        grid.addWidget(self.cb_enhancer, len(items) // 2, 1)
+        grid.addWidget(self.cb_enhancer, enhancer_row, 1)
 
         return card
 
@@ -1198,6 +1243,44 @@ class WebcamPreviewWindow(QWidget):
         self._processed_queue: queue.Queue = queue.Queue(maxsize=2)
         self._stop_event = threading.Event()
 
+        # Optional virtual camera output (pyvirtualcam → OBS Virtual Camera).
+        # Snapshot the global at start so toggling mid-session doesn't crash
+        # the send loop; user must Stop+Start to change vcam state.
+        self._vcam = None
+        self._vcam_last_send_ts = 0.0
+        vcam_requested = getattr(modules.globals, "virtual_cam", False)
+        print(f"[vcam] Live start — virtual_cam global = {vcam_requested}")
+        if vcam_requested:
+            try:
+                import pyvirtualcam
+                self._vcam = pyvirtualcam.Camera(
+                    width=VCAM_W, height=VCAM_H, fps=VCAM_FPS
+                )
+                update_status(
+                    f"Virtual camera started: {self._vcam.device} @ {VCAM_W}x{VCAM_H}"
+                )
+            except ImportError:
+                update_status("pyvirtualcam not installed — pip install pyvirtualcam")
+                self._vcam = None
+            except Exception as e:
+                update_status(
+                    f"Virtual camera failed: {e}. Install OBS Studio for the OBS Virtual Camera driver."
+                )
+                self._vcam = None
+
+        # In vcam mode, replace the live preview with a static status
+        # message and shrink the window. Saves the cv2.resize + Qt repaint
+        # each tick, but keeps the window's X button as the stop control —
+        # same UX as the regular Live close flow.
+        if self._vcam is not None:
+            self.setWindowTitle("Virtual Cam — Live")
+            self.resize(360, 140)
+            self._image_label.setText(
+                "Virtual Cam is sending frames\nto OBS Virtual Camera.\n\n"
+                "Close this window to stop."
+            )
+            self._image_label.setStyleSheet("font-size: 14px; padding: 12px;")
+
         self._capture_worker = _CaptureWorker(
             self._cap, self._capture_queue, self._stop_event
         )
@@ -1221,8 +1304,45 @@ class WebcamPreviewWindow(QWidget):
             bgr_frame = self._processed_queue.get_nowait()
         except queue.Empty:
             return
-        bgr_frame = fit_image_to_size(bgr_frame, self.width(), self.height())
-        self._image_label.setPixmap(_bgr_to_qpixmap(bgr_frame))
+
+        # Send to virtual camera BEFORE the display fit-resize so meeting
+        # apps always see the full processed frame at a stable 1280x720,
+        # regardless of how the user has resized the preview window.
+        # Aspect-preserving center crop: many webcams negotiate 4:3 even
+        # when 16:9 is requested (e.g. 360p -> 480p). A plain resize to
+        # 1280x720 would horizontally squash that 4:3 frame, so we crop
+        # the longer axis to match the 16:9 output ratio first.
+        if self._vcam is not None:
+            # Pace to VCAM_FPS — the webcam path can deliver frames faster
+            # (e.g. 60fps), but we advertise 30fps to meeting apps. Skip
+            # ticks until enough wall-clock has elapsed since the last send.
+            # Wall-clock gating (rather than cam.sleep_until_next_frame())
+            # avoids blocking the Qt event loop.
+            now = time.monotonic()
+            if now - self._vcam_last_send_ts >= 1.0 / VCAM_FPS:
+                try:
+                    vcam_frame = _aspect_crop_to(bgr_frame, VCAM_W, VCAM_H)
+                    rgb = cv2.cvtColor(vcam_frame, cv2.COLOR_BGR2RGB)
+                    self._vcam.send(rgb)
+                    self._vcam_last_send_ts = now
+                except Exception as e:
+                    # Don't kill the preview if vcam misbehaves — just log once.
+                    if not getattr(self, "_vcam_warned", False):
+                        update_status(f"Virtual camera send error (continuing without vcam): {e}")
+                        self._vcam_warned = True
+                    try:
+                        self._vcam.close()
+                    except Exception:
+                        pass
+                    self._vcam = None
+
+        # Skip the display-side resize + Qt pixmap conversion when in
+        # vcam mode (the label shows a static status string instead of
+        # the live preview). Saves the cv2.resize and the BGR→QImage
+        # copy each tick.
+        if self._vcam is None:
+            bgr_frame = fit_image_to_size(bgr_frame, self.width(), self.height())
+            self._image_label.setPixmap(_bgr_to_qpixmap(bgr_frame))
 
     def closeEvent(self, event) -> None:
         self._stop_event.set()
@@ -1239,17 +1359,32 @@ class WebcamPreviewWindow(QWidget):
             self._cap.release()
         except Exception:
             pass
+        if getattr(self, "_vcam", None) is not None:
+            try:
+                self._vcam.close()
+            except Exception:
+                pass
+            self._vcam = None
         global _WEBCAM_PREVIEW
         if _WEBCAM_PREVIEW is self:
             _WEBCAM_PREVIEW = None
+        # Notify whoever opened us (typically MainWindow) so they can
+        # reset their button state regardless of how we got closed.
+        cb = getattr(self, "_on_close_callback", None)
+        if cb is not None:
+            try:
+                cb()
+            except Exception as e:
+                print(f"[live] on_close callback raised: {e}")
         event.accept()
 
 
-def _open_webcam_preview(camera_index: int) -> None:
+def _open_webcam_preview(camera_index: int, on_close=None) -> None:
     global _WEBCAM_PREVIEW
     if _WEBCAM_PREVIEW is not None:
         _WEBCAM_PREVIEW.close()
     _WEBCAM_PREVIEW = WebcamPreviewWindow(camera_index)
+    _WEBCAM_PREVIEW._on_close_callback = on_close
     _WEBCAM_PREVIEW.show()
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,6 @@ tensorflow>=2.15.0; sys_platform == 'darwin' and python_version < '3.13'
 opennsfw2==0.10.2
 protobuf==4.25.1
 pygrabber; sys_platform == 'win32'
+pyvirtualcam>=0.15.0
+# Note: pyvirtualcam needs OBS Studio installed on the host for the OBS
+# Virtual Camera driver. The pip package alone won't expose a virtual cam.


### PR DESCRIPTION
## Summary

Adds a **Virtual Cam** toggle in the Options card. When enabled at Live start, processed frames are sent to a virtual webcam (OBS Virtual Camera driver on Windows/macOS, `v4l2loopback` on Linux) so apps like Discord, Zoom, Google Meet, and Teams can pick the swapped face up as a webcam input.

Output is fixed at **1280×720 / 30fps** so meeting apps see a stable size regardless of the underlying capture resolution.

## Why

Currently the swapped output is preview-window only — useful for demos but not for the workflow most people actually want (looking like someone else on a video call). `pyvirtualcam` is the de-facto Python bridge to the OBS Virtual Camera driver (Windows + macOS) and `v4l2loopback` (Linux). Users still need to install OBS Studio for the driver itself; this is documented in the tooltip and the failure-path status messages.

## Why fixed at 1280×720 / 30fps (and not configurable)

- **Meeting-app standard.** Zoom, Meet, Teams, Discord all default to 720p and many cap higher inputs to 720p anyway. Going to 1080p costs noticeable extra CPU/GPU for the upscale+send without visible quality gain on the receiving end.
- **Aspect stability.** 16:9 is what every meeting app expects, and `_aspect_crop_to` already handles the common 4:3 (e.g. 640×480) negotiated-input case so faces aren't horizontally squashed.
- **30fps ceiling.** Meeting apps generally cap at 30fps; higher just costs more compute for no perceived smoothness gain.
- **pyvirtualcam constraint.** The vcam stream's width/height/fps are set at `pyvirtualcam.Camera()` creation and can't change mid-session, so any configurability would need to be a one-time choice at Live-start (e.g. a dropdown) rather than a live setting.

If/when #1833 (capture resolution + det_size dropdowns) lands, the vcam output dimensions could be tied to the user-selected capture resolution — but that PR isn't in yet, and upstream main currently has no user-facing resolution config to hook into. Exposing `VCAM_W`/`VCAM_H`/`VCAM_FPS` as user-configurable is intentionally kept out of scope here to keep this PR minimal and focused on the vcam plumbing itself. Happy to do it as a separate PR once #1833 (or some equivalent resolution selector) is in.

## What changed

- **`requirements.txt`** — `pyvirtualcam>=0.15.0` (with a comment about the OBS Studio host requirement)
- **`modules/globals.py`** — `virtual_cam: bool = False` toggle
- **`modules/ui.py`**:
  - `VCAM_W=1280`, `VCAM_H=720`, `VCAM_FPS=30` constants
  - `_aspect_crop_to(frame, w, h)` — channel-count-agnostic center crop to the target aspect before resize. Many webcams negotiate 4:3 (e.g. 640×480) even when 16:9 is requested, and a bare resize to 1280×720 horizontally stretches faces.
  - `WebcamPreviewWindow.__init__` — opens `pyvirtualcam.Camera()` when `virtual_cam` is True; clear status messages on `ImportError` / driver-missing without killing the preview loop.
  - When vcam is active the preview window shrinks to ~360×140 and shows a static status message; closing it via X stops capture / processing / vcam — same UX as a normal preview close.
  - `_tick` sends each processed frame to vcam **before** the display fit-resize, with wall-clock pacing (`time.monotonic()` gating, not `cam.sleep_until_next_frame()` because we're inside a `QTimer` callback and can't block the Qt event loop) to honor the advertised 30fps even when the webcam path delivers frames faster.
  - On send failure the vcam handle is closed before being dropped, a single status message is emitted via `update_status()`, and the preview loop continues without vcam.
  - `virtual_cam` is included in `save_switch_states` / `load_switch_states` so the toggle persists across launches like the other switches.

## Tested

Verified on Windows + Google Meet with OBS Virtual Camera installed — swapped face shows up at 720p in the call.

## Re #1834

Re-submission of #1834 (closed) with @kier007's review feedback applied:

1. Explicit frame pacing to honor the 30fps contract
2. `self._vcam.close()` on send failure before disabling, so the handle doesn't leak until preview close
3. Toggle persistence via `save_switch_states` / `load_switch_states`
4. Status-channel logging (`update_status()`) instead of `print()` on send error

Also includes the @sourcery-ai fix from that PR (drop explicit 3rd-axis slice in `_aspect_crop_to` for channel-count robustness).