### PR TITLE
fix: skip setrlimit(RLIMIT_DATA) on macOS

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -170,8 +170,8 @@ def limit_resources() -> None:
             tensorflow.config.experimental.set_memory_growth(gpu, True)
     # limit memory usage
     if modules.globals.max_memory:
-        # setrlimit(RLIMIT_DATA) is unusable on macOS.
-        # See https://github.com/python/cpython/issues/142317
+        # setrlimit(RLIMIT_DATA) fails with EINVAL on macOS, crashing on launch.
+        # See https://github.com/hacksider/Deep-Live-Cam/issues/1848
         if platform.system().lower() == 'darwin':
             return
         memory = modules.globals.max_memory * 1024 ** 3

--- a/modules/core.py
+++ b/modules/core.py
@@ -170,6 +170,10 @@ def limit_resources() -> None:
             tensorflow.config.experimental.set_memory_growth(gpu, True)
     # limit memory usage
     if modules.globals.max_memory:
+        # setrlimit(RLIMIT_DATA) is unusable on macOS.
+        # See https://github.com/python/cpython/issues/142317
+        if platform.system().lower() == 'darwin':
+            return
         memory = modules.globals.max_memory * 1024 ** 3
         if platform.system().lower() == 'windows':
             import ctypes


### PR DESCRIPTION
Fixes #1848.

The macOS kernel rejects `setrlimit(RLIMIT_DATA, ...)` with EINVAL for the values used here, crashing the app on launch. Skip the call on darwin.

## Summary by Sourcery

Bug Fixes:
- Prevent crashes on macOS by not calling setrlimit(RLIMIT_DATA) with unsupported values when limiting memory usage.
