### PR TITLE
Fix macOS 15 RLIMIT_DATA crash and webcam close AttributeError

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -177,7 +177,13 @@ def limit_resources() -> None:
             kernel32.SetProcessWorkingSetSize(-1, ctypes.c_size_t(memory), ctypes.c_size_t(memory))
         else:
             import resource
-            resource.setrlimit(resource.RLIMIT_DATA, (memory, memory))
+            _, hard = resource.getrlimit(resource.RLIMIT_DATA)
+            if hard != resource.RLIM_INFINITY:
+                memory = min(memory, hard)
+            try:
+                resource.setrlimit(resource.RLIMIT_DATA, (memory, memory))
+            except ValueError:
+                pass
 
 
 def release_resources() -> None:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1226,6 +1226,9 @@ class WebcamPreviewWindow(QWidget):
         self._image_label.setPixmap(_bgr_to_qpixmap(bgr_frame))
 
     def closeEvent(self, event) -> None:
+        if not hasattr(self, '_stop_event'):
+            event.accept()
+            return
         self._stop_event.set()
         try:
             self._timer.stop()


### PR DESCRIPTION
On macOS 15, resource.setrlimit(RLIMIT_DATA) raises ValueError when the requested limit exceeds the OS hard limit. Clamp to the hard limit first and catch any remaining ValueError so the app still starts.

In WebcamPreviewWindow.closeEvent, accessing _stop_event before it is initialized (camera open failure causes early return before the Event is created) raises AttributeError. Guard with hasattr so closing the window after a failed camera open is handled gracefully.

## Summary
- Fix `ValueError: current limit exceeds maximum limit` crash on macOS 15 when `--max-memory` is set — clamp to the OS hard limit before calling `setrlimit(RLIMIT_DATA)`
- Fix `AttributeError: 'WebcamPreviewWindow' object has no attribute '_stop_event'` when closing the window after a camera open failure — `_stop_event` is only created after a successful camera open, so `closeEvent` needs a guard

## Test plan
- [ ] Run on macOS 15 Apple Silicon — app starts without crashing
- [ ] Open Live Preview when camera fails to initialize — closing the window does not raise AttributeError
- [ ] Run with `--max-memory` flag — no crash

## Summary by Sourcery

Handle resource limit failures on macOS and make webcam preview window closing robust after camera initialization failures.

Bug Fixes:
- Prevent crashes on macOS when setting RLIMIT_DATA by clamping to the OS hard limit and ignoring unsupported configurations.
- Avoid AttributeError when closing the webcam preview window after a failed camera initialization by guarding access to the stop event.