### PR TITLE
feat: GFPGAN model selector with hot-swap

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -70,6 +70,13 @@ enable_interpolation: bool = True # Toggle temporal smoothing
 interpolation_weight: float = 0  # Blend weight for current frame (0.0-1.0). Lower=smoother.
 # --- END: Added for Frame Interpolation ---
 
+# GFPGAN model filename. Currently shipped variants:
+#   gfpgan-1024.onnx  — 512 in, 1024 out (super-res head). Highest quality.
+#   GFPGANv1.4.onnx   — 512 in, 512 out. Lighter, faster.
+# Both files are hosted on the hacksider/deep-live-cam HF model repo.
+# Hot-swap supported via reset_face_enhancer() (called from UI on change).
+gfpgan_model_filename: str = "gfpgan-1024.onnx"
+
 # --- END OF FILE globals.py ---
 
 import threading

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -23,6 +23,15 @@ THREAD_SEMAPHORE = threading.Semaphore()
 THREAD_LOCK = threading.Lock()
 NAME = "DLC.FACE-ENHANCER"
 
+# Whitelist of shipped GFPGAN ONNX variants. Guards _gfpgan_model_path against
+# a corrupt/hand-edited gfpgan_model_filename (typo or path traversal) reaching
+# onnxruntime — anything unrecognized falls back to the default.
+_GFPGAN_MODELS = ("gfpgan-1024.onnx", "GFPGANv1.4.onnx")
+_GFPGAN_DEFAULT = "gfpgan-1024.onnx"
+# Set when a model fails to load so the per-frame degrade path warns once
+# instead of spamming the status bar every frame. Cleared on reset.
+_enh_load_warned = False
+
 abs_dir = os.path.dirname(os.path.abspath(__file__))
 models_dir = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(abs_dir))), "models"
@@ -43,21 +52,45 @@ FFHQ_TEMPLATE_512 = np.array(
 
 
 def _gfpgan_model_path() -> str:
-    filename = getattr(modules.globals, "gfpgan_model_filename", "gfpgan-1024.onnx")
+    filename = getattr(modules.globals, "gfpgan_model_filename", _GFPGAN_DEFAULT)
+    if filename not in _GFPGAN_MODELS:
+        filename = _GFPGAN_DEFAULT
     return os.path.join(models_dir, filename)
 
 
-def reset_face_enhancer() -> None:
-    """Drop the cached GFPGAN session so next call reloads with current
-    globals.gfpgan_model_filename. Called by the UI on enhancer dropdown
-    change so the user can hot-swap GFPGAN-1024 ⇄ GFPGAN-512 mid-session.
+def reset_face_enhancer(model_filename: str | None = None) -> None:
+    """Drop the cached GFPGAN session so the next call reloads from disk.
+
+    Called by the UI on enhancer dropdown change so the user can hot-swap
+    GFPGAN-1024 <-> GFPGAN-512 mid-session. Pass ``model_filename`` to switch
+    variants atomically: the filename, the cached session and all derived
+    caches are updated together under THREAD_LOCK, so a worker mid-frame can
+    never observe a new filename with a stale session (or vice versa).
     """
-    global FACE_ENHANCER
+    global FACE_ENHANCER, _enh_load_warned
     with THREAD_LOCK:
+        if model_filename is not None:
+            modules.globals.gfpgan_model_filename = model_filename
+        old_session = FACE_ENHANCER
         FACE_ENHANCER = None
-        # Also invalidate the feathered-mask cache — output size will likely change
+        _enh_load_warned = False
+        # Invalidate the feathered-mask cache — output size likely changes.
         _enhancer_cache['mask'] = None
         _enhancer_cache['mask_size'] = 0
+        # Invalidate the temporal (live) cache too — it holds the previous
+        # model's enhanced face/affine at the old align size; reusing it after
+        # a switch would paste a mismatched-size face for a frame or two.
+        _enh_live_cache['enhanced_bgr'] = None
+        _enh_live_cache['affine_matrix'] = None
+        _enh_live_cache['align_size'] = 0
+        _enh_live_cache['frame_count'] = 0
+    # Release the old onnxruntime session's VRAM promptly. onnxruntime exposes
+    # no close(), so drop the last reference and force a collection; done
+    # outside the lock so collection never blocks a waiting worker.
+    if old_session is not None:
+        del old_session
+        import gc
+        gc.collect()
 
 
 def pre_check() -> bool:
@@ -102,7 +135,7 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
                     create_onnx_session,
                 )
 
-                print(f"{NAME}: Loading GFPGAN ONNX model from {model_path}")
+                update_status(f"Loading GFPGAN ONNX model from {model_path}", NAME)
                 FACE_ENHANCER = create_onnx_session(model_path)
 
                 input_info = FACE_ENHANCER.get_inputs()[0]
@@ -122,7 +155,7 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
                 print(f"{NAME}: Active providers: {active_providers}")
 
             except Exception as e:
-                print(f"{NAME}: Error loading GFPGAN ONNX model: {e}")
+                update_status(f"Error loading GFPGAN ONNX model: {e}", NAME)
                 FACE_ENHANCER = None
                 raise RuntimeError(
                     f"{NAME}: Failed to load GFPGAN ONNX model: {e}"
@@ -197,18 +230,23 @@ def _paste_back(
     h, w = frame.shape[:2]
     inv_matrix = cv2.invertAffineTransform(affine_matrix)
 
-    # Build or reuse cached feathered mask (uint8 — blended via cv2 SIMD ops)
-    if _enhancer_cache['mask_size'] != output_size:
-        face_mask_f = np.ones((output_size, output_size), dtype=np.float32)
-        border = max(1, int(output_size * 0.05))
-        ramp_up = np.linspace(0.0, 1.0, border, dtype=np.float32)
-        ramp_down = np.linspace(1.0, 0.0, border, dtype=np.float32)
-        face_mask_f[:border, :] *= ramp_up[:, None]
-        face_mask_f[-border:, :] *= ramp_down[:, None]
-        face_mask_f[:, :border] *= ramp_up[None, :]
-        face_mask_f[:, -border:] *= ramp_down[None, :]
-        _enhancer_cache['mask'] = (face_mask_f * 255.0).astype(np.uint8)
-        _enhancer_cache['mask_size'] = output_size
+    # Build or reuse cached feathered mask (uint8 — blended via cv2 SIMD ops).
+    # Done under THREAD_LOCK and snapshotted into a local so a concurrent
+    # reset_face_enhancer() (which nulls the cache) can't race the read below
+    # and hand cv2.warpAffine a None mask.
+    with THREAD_LOCK:
+        if _enhancer_cache['mask_size'] != output_size:
+            face_mask_f = np.ones((output_size, output_size), dtype=np.float32)
+            border = max(1, int(output_size * 0.05))
+            ramp_up = np.linspace(0.0, 1.0, border, dtype=np.float32)
+            ramp_down = np.linspace(1.0, 0.0, border, dtype=np.float32)
+            face_mask_f[:border, :] *= ramp_up[:, None]
+            face_mask_f[-border:, :] *= ramp_down[:, None]
+            face_mask_f[:, :border] *= ramp_up[None, :]
+            face_mask_f[:, -border:] *= ramp_down[None, :]
+            _enhancer_cache['mask'] = (face_mask_f * 255.0).astype(np.uint8)
+            _enhancer_cache['mask_size'] = output_size
+        mask = _enhancer_cache['mask']
 
     # Compute tight bbox from affine corners (avoids full-frame warpAffine scan)
     corners = np.array([[0, 0], [output_size, 0],
@@ -238,7 +276,7 @@ def _paste_back(
         borderMode=cv2.BORDER_CONSTANT, borderValue=(0, 0, 0),
     )
     inv_mask_crop = cv2.warpAffine(
-        _enhancer_cache['mask'], inv_crop, (crop_w, crop_h),
+        mask, inv_crop, (crop_w, crop_h),
         borderMode=cv2.BORDER_CONSTANT, borderValue=0,
     )
 
@@ -312,7 +350,18 @@ def enhance_face(temp_frame: Frame, detected_faces=None) -> Frame:
             Also enables temporal caching — inference runs every
             _ENH_INTERVAL frames, reusing the cached result otherwise.
     """
-    session = get_face_enhancer()
+    global _enh_load_warned
+    try:
+        session = get_face_enhancer()
+    except Exception as e:
+        # A missing/corrupt model (e.g. user picked GFPGAN-512 but only has
+        # the 1024 file) must NOT propagate — it would unwind out of the live
+        # worker thread and freeze the preview. Degrade to passthrough and
+        # warn once until the model is fixed or another variant is selected.
+        if not _enh_load_warned:
+            update_status(f"Face enhancer disabled: {e}", NAME)
+            _enh_load_warned = True
+        return temp_frame
 
     # Determine model input resolution from the session metadata
     input_info = session.get_inputs()[0]

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -55,9 +55,9 @@ def reset_face_enhancer() -> None:
     global FACE_ENHANCER
     with THREAD_LOCK:
         FACE_ENHANCER = None
-    # Also invalidate the feathered-mask cache — output size will likely change
-    _enhancer_cache['mask'] = None
-    _enhancer_cache['mask_size'] = 0
+        # Also invalidate the feathered-mask cache — output size will likely change
+        _enhancer_cache['mask'] = None
+        _enhancer_cache['mask_size'] = 0
 
 
 def pre_check() -> bool:

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -430,11 +430,21 @@ def enhance_face(temp_frame: Frame, detected_faces=None) -> Frame:
                         interpolation=cv2.INTER_LANCZOS4,
                     )
 
-                # Cache for reuse on next frame
+                # Cache for reuse on next frame — commit under THREAD_LOCK and
+                # only if our session is still the active one. A concurrent
+                # reset_face_enhancer() (model hot-swap) nulls FACE_ENHANCER and
+                # clears this cache under the same lock; without the guard, a
+                # frame whose inference ran on the now-replaced session could
+                # resurrect the old model's output into the just-cleared cache
+                # for the next frame to reuse. `FACE_ENHANCER is session` acts
+                # as a model-generation tag: if a reset swapped the session out
+                # from under us, drop the stale result instead of caching it.
                 if use_cache:
-                    _enh_live_cache['enhanced_bgr'] = enhanced_bgr
-                    _enh_live_cache['affine_matrix'] = affine_matrix
-                    _enh_live_cache['align_size'] = align_size
+                    with THREAD_LOCK:
+                        if FACE_ENHANCER is session:
+                            _enh_live_cache['enhanced_bgr'] = enhanced_bgr
+                            _enh_live_cache['affine_matrix'] = affine_matrix
+                            _enh_live_cache['align_size'] = align_size
 
                 _paste_back(
                     temp_frame, enhanced_bgr, affine_matrix, output_size=align_size

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -42,12 +42,30 @@ FFHQ_TEMPLATE_512 = np.array(
 )
 
 
+def _gfpgan_model_path() -> str:
+    filename = getattr(modules.globals, "gfpgan_model_filename", "gfpgan-1024.onnx")
+    return os.path.join(models_dir, filename)
+
+
+def reset_face_enhancer() -> None:
+    """Drop the cached GFPGAN session so next call reloads with current
+    globals.gfpgan_model_filename. Called by the UI on enhancer dropdown
+    change so the user can hot-swap GFPGAN-1024 ⇄ GFPGAN-512 mid-session.
+    """
+    global FACE_ENHANCER
+    with THREAD_LOCK:
+        FACE_ENHANCER = None
+    # Also invalidate the feathered-mask cache — output size will likely change
+    _enhancer_cache['mask'] = None
+    _enhancer_cache['mask_size'] = 0
+
+
 def pre_check() -> bool:
-    model_path = os.path.join(models_dir, "gfpgan-1024.onnx")
+    model_path = _gfpgan_model_path()
     if not os.path.exists(model_path):
         update_status(
             f"GFPGAN ONNX model not found at {model_path}. "
-            "Please place gfpgan-1024.onnx in the models folder.",
+            f"Place {os.path.basename(model_path)} in the models folder.",
             NAME,
         )
         return False
@@ -72,7 +90,7 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
 
     with THREAD_LOCK:
         if FACE_ENHANCER is None:
-            model_path = os.path.join(models_dir, "gfpgan-1024.onnx")
+            model_path = _gfpgan_model_path()
 
             if not os.path.exists(model_path):
                 raise FileNotFoundError(
@@ -84,6 +102,7 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
                     create_onnx_session,
                 )
 
+                print(f"{NAME}: Loading GFPGAN ONNX model from {model_path}")
                 FACE_ENHANCER = create_onnx_session(model_path)
 
                 input_info = FACE_ENHANCER.get_inputs()[0]

--- a/modules/processors/frame/face_enhancer.py
+++ b/modules/processors/frame/face_enhancer.py
@@ -5,13 +5,14 @@ import cv2
 import threading
 import numpy as np
 import os
+import gc
 
 import onnxruntime
 
 import modules.globals
 import modules.processors.frame.core
 from modules.core import update_status
-from modules.face_analyser import get_one_face, get_many_faces
+from modules.face_analyser import get_many_faces
 from modules.typing import Frame, Face
 from modules.utilities import (
     is_image,
@@ -89,7 +90,6 @@ def reset_face_enhancer(model_filename: str | None = None) -> None:
     # outside the lock so collection never blocks a waiting worker.
     if old_session is not None:
         del old_session
-        import gc
         gc.collect()
 
 
@@ -135,7 +135,12 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
                     create_onnx_session,
                 )
 
-                update_status(f"Loading GFPGAN ONNX model from {model_path}", NAME)
+                # print (not update_status): runs under THREAD_LOCK, and
+                # update_status can re-enter the Qt event loop (processEvents)
+                # on the UI thread and deadlock on the non-reentrant lock.
+                # The user-facing failure is surfaced by enhance_face's
+                # handler, outside the lock.
+                print(f"{NAME}: Loading GFPGAN ONNX model from {model_path}")
                 FACE_ENHANCER = create_onnx_session(model_path)
 
                 input_info = FACE_ENHANCER.get_inputs()[0]
@@ -155,18 +160,19 @@ def get_face_enhancer() -> onnxruntime.InferenceSession:
                 print(f"{NAME}: Active providers: {active_providers}")
 
             except Exception as e:
-                update_status(f"Error loading GFPGAN ONNX model: {e}", NAME)
                 FACE_ENHANCER = None
                 raise RuntimeError(
                     f"{NAME}: Failed to load GFPGAN ONNX model: {e}"
                 )
 
-    if FACE_ENHANCER is None:
-        raise RuntimeError(
-            f"{NAME}: Failed to initialize GFPGAN ONNX session. Check logs."
-        )
-
-    return FACE_ENHANCER
+        # Validate + return under the lock so a concurrent reset_face_enhancer()
+        # can't null FACE_ENHANCER between this check and the return (which would
+        # hand the worker None -> AttributeError on session.get_inputs()).
+        if FACE_ENHANCER is None:
+            raise RuntimeError(
+                f"{NAME}: Failed to initialize GFPGAN ONNX session. Check logs."
+            )
+        return FACE_ENHANCER
 
 
 def _align_face(
@@ -437,13 +443,19 @@ def enhance_face(temp_frame: Frame, detected_faces=None) -> Frame:
                 print(f"{NAME}: Error enhancing a face: {e}")
                 continue
         else:
-            # Reuse cached enhanced face — just paste back onto current frame
-            cached = _enh_live_cache
-            if cached['enhanced_bgr'] is not None:
+            # Reuse cached enhanced face — just paste back onto current frame.
+            # Snapshot all three fields together under THREAD_LOCK: a concurrent
+            # reset_face_enhancer() nulls them as a set, so an unlocked multi-read
+            # could see enhanced_bgr still set but affine_matrix already None and
+            # hand _paste_back a None matrix (crash in invertAffineTransform).
+            with THREAD_LOCK:
+                cached_bgr = _enh_live_cache['enhanced_bgr']
+                cached_affine = _enh_live_cache['affine_matrix']
+                cached_align = _enh_live_cache['align_size']
+            if cached_bgr is not None:
                 _paste_back(
-                    temp_frame, cached['enhanced_bgr'],
-                    cached['affine_matrix'],
-                    output_size=cached['align_size'],
+                    temp_frame, cached_bgr, cached_affine,
+                    output_size=cached_align,
                 )
         if not many_faces_mode:
             break  # single-face live mode — only process first face

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -614,10 +614,12 @@ class MainWindow(QMainWindow):
         grid.addWidget(enhancer_label, len(items) // 2, 0)
 
         self.cb_enhancer = QComboBox()
-        self.cb_enhancer.addItems(["None", "GFPGAN", "GPEN-512", "GPEN-256"])
+        self.cb_enhancer.addItems(["None", "GFPGAN-1024", "GFPGAN-512", "GPEN-512", "GPEN-256"])
         initial = "None"
         if modules.globals.fp_ui.get("face_enhancer", False):
-            initial = "GFPGAN"
+            # Pick the GFPGAN variant currently selected via globals
+            fn = getattr(modules.globals, "gfpgan_model_filename", "gfpgan-1024.onnx")
+            initial = "GFPGAN-512" if fn == "GFPGANv1.4.onnx" else "GFPGAN-1024"
         elif modules.globals.fp_ui.get("face_enhancer_gpen512", False):
             initial = "GPEN-512"
         elif modules.globals.fp_ui.get("face_enhancer_gpen256", False):
@@ -817,17 +819,36 @@ class MainWindow(QMainWindow):
             close_mapper_window()
 
     def _on_enhancer_change(self, choice: str) -> None:
+        # Both GFPGAN variants use the same processor (face_enhancer) but
+        # differ in which ONNX model file is loaded.
         key_map = {
             "None": None,
-            "GFPGAN": "face_enhancer",
+            "GFPGAN-1024": "face_enhancer",
+            "GFPGAN-512": "face_enhancer",
             "GPEN-512": "face_enhancer_gpen512",
             "GPEN-256": "face_enhancer_gpen256",
         }
+        gfpgan_filename = {
+            "GFPGAN-1024": "gfpgan-1024.onnx",
+            "GFPGAN-512": "GFPGANv1.4.onnx",
+        }
+
         for key in ("face_enhancer", "face_enhancer_gpen256", "face_enhancer_gpen512"):
             _update_tumbler(key, False)
         selected = key_map.get(choice)
         if selected:
             _update_tumbler(selected, True)
+
+        # If user picked a GFPGAN variant, update the model filename and
+        # drop the cached session so the next inference reloads from disk.
+        if choice in gfpgan_filename:
+            prev = getattr(modules.globals, "gfpgan_model_filename", None)
+            modules.globals.gfpgan_model_filename = gfpgan_filename[choice]
+            if prev != gfpgan_filename[choice]:
+                from modules.processors.frame.face_enhancer import reset_face_enhancer
+                reset_face_enhancer()
+                update_status(f"GFPGAN model set to {gfpgan_filename[choice]}")
+
         save_switch_states()
 
     def _on_transparency_change(self, value: float) -> None:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -856,12 +856,16 @@ class MainWindow(QMainWindow):
         # reset_face_enhancer(new_fn) sets the filename and drops the cached
         # session + derived caches under one lock, so the live worker can never
         # observe a new filename paired with a stale session (or vice versa).
+        from modules.processors.frame.face_enhancer import reset_face_enhancer
         if choice in gfpgan_filename:
             new_fn = gfpgan_filename[choice]
             if getattr(modules.globals, "gfpgan_model_filename", None) != new_fn:
-                from modules.processors.frame.face_enhancer import reset_face_enhancer
                 reset_face_enhancer(new_fn)
-                update_status(f"GFPGAN model set to {new_fn}")
+                update_status(_("GFPGAN model set to") + f" {new_fn}")
+        else:
+            # Switched to a GPEN variant or None — drop the cached GFPGAN
+            # session so its VRAM isn't pinned for the rest of the session.
+            reset_face_enhancer()
 
         save_switch_states()
 

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -313,6 +313,7 @@ def save_switch_states():
         "mouth_mask": modules.globals.mouth_mask,
         "show_mouth_mask_box": modules.globals.show_mouth_mask_box,
         "mouth_mask_size": modules.globals.mouth_mask_size,
+        "gfpgan_model_filename": modules.globals.gfpgan_model_filename,
     }
     try:
         with open("switch_states.json", "w") as f:
@@ -335,13 +336,25 @@ def load_switch_states():
         modules.globals.nsfw_filter = state.get("nsfw_filter", False)
         modules.globals.live_mirror = state.get("live_mirror", False)
         modules.globals.live_resizable = state.get("live_resizable", False)
-        modules.globals.fp_ui = state.get("fp_ui", {"face_enhancer": False})
+        # Normalize fp_ui so every expected key exists — the live worker reads
+        # fp_ui["face_enhancer"] by subscript, which would KeyError on a
+        # persisted dict that omitted it.
+        fp = state.get("fp_ui") or {}
+        modules.globals.fp_ui = {
+            "face_enhancer": fp.get("face_enhancer", False),
+            "face_enhancer_gpen256": fp.get("face_enhancer_gpen256", False),
+            "face_enhancer_gpen512": fp.get("face_enhancer_gpen512", False),
+        }
         modules.globals.show_fps = state.get("show_fps", False)
         # Mouth mask always starts disabled (slider at 0) on launch,
         # regardless of the persisted value — enable it explicitly each session.
         modules.globals.mouth_mask_size = 0.0
         modules.globals.mouth_mask = False
         modules.globals.show_mouth_mask_box = False
+        # Restore the GFPGAN variant; reject unknown values (corrupt file or a
+        # removed model file) so a bad filename can't reach onnxruntime.
+        if state.get("gfpgan_model_filename") in ("gfpgan-1024.onnx", "GFPGANv1.4.onnx"):
+            modules.globals.gfpgan_model_filename = state["gfpgan_model_filename"]
     except FileNotFoundError:
         pass
     except (OSError, json.JSONDecodeError):
@@ -839,15 +852,16 @@ class MainWindow(QMainWindow):
         if selected:
             _update_tumbler(selected, True)
 
-        # If user picked a GFPGAN variant, update the model filename and
-        # drop the cached session so the next inference reloads from disk.
+        # If the user picked a GFPGAN variant, switch models atomically:
+        # reset_face_enhancer(new_fn) sets the filename and drops the cached
+        # session + derived caches under one lock, so the live worker can never
+        # observe a new filename paired with a stale session (or vice versa).
         if choice in gfpgan_filename:
-            prev = getattr(modules.globals, "gfpgan_model_filename", None)
-            modules.globals.gfpgan_model_filename = gfpgan_filename[choice]
-            if prev != gfpgan_filename[choice]:
+            new_fn = gfpgan_filename[choice]
+            if getattr(modules.globals, "gfpgan_model_filename", None) != new_fn:
                 from modules.processors.frame.face_enhancer import reset_face_enhancer
-                reset_face_enhancer()
-                update_status(f"GFPGAN model set to {gfpgan_filename[choice]}")
+                reset_face_enhancer(new_fn)
+                update_status(f"GFPGAN model set to {new_fn}")
 
         save_switch_states()
 


### PR DESCRIPTION
Adds a GFPGAN model selector with live hot-swap. Re-submission of #1832 (closed); same branch, rebuilt against current `main` with the earlier review feedback applied.

## What
- UI selector to switch the GFPGAN ONNX variant (1024 high-quality ↔ 512 lighter/faster) without restart.

## Review feedback addressed
- **Crash-safe load** — `get_face_enhancer` validates and returns the session inside `THREAD_LOCK`; a failed load sets `FACE_ENHANCER = None` and raises instead of leaving a half-initialized global.
- **No Qt deadlock** — stopped calling `update_status` while holding the non-reentrant lock (Qt's `processEvents` re-entrancy could deadlock it); model load now logs to console.
- **Variant persists** — switching model updates `gfpgan_model_filename` so the choice survives restart; switching away to a GPEN variant or None drops the cached GFPGAN session to free VRAM.
- **Cache race fixed** — `enhance_face` snapshots the temporal cache under the lock so a concurrent `reset_face_enhancer()` can't hand `_paste_back` a half-cleared matrix.

Ruff gate (`E701,E711,E712,F401,F541`) clean; live-tested 1024↔512 hot-swap and a full GPEN round-trip; variant persisted across restart.

## Summary by Sourcery

Add selectable GFPGAN ONNX variants with hot-swappable model switching and safer session management in the face enhancer pipeline.

New Features:
- Introduce a UI dropdown to choose between 1024 and 512 GFPGAN ONNX variants for face enhancement.
- Persist the selected GFPGAN model filename across sessions via switch state storage.

Enhancements:
- Make GFPGAN model loading crash-safe and thread-safe, including validation under a shared lock and clearer fallback behavior when models are missing or invalid.
- Guard and reset internal face enhancement caches when switching models to avoid mismatched outputs and races.
- Normalize persisted face processor UI state to ensure all expected keys are present when loading.