### PR TITLE
feat: WEBP source image support

### DIFF
--- a/modules/globals.py
+++ b/modules/globals.py
@@ -7,7 +7,7 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 WORKFLOW_DIR = os.path.join(ROOT_DIR, "workflow")
 
 file_types = [
-    ("Image", ("*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp")),
+    ("Image", ("*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp", "*.webp")),
     ("Video", ("*.mp4", "*.mkv")),
 ]
 

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -6,9 +6,17 @@ from typing import List, Dict, Any
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 WORKFLOW_DIR = os.path.join(ROOT_DIR, "workflow")
 
+# Canonical media extensions, defined once so file dialogs, file_types and
+# has_image_extension never drift. GIF is intentionally excluded: OpenCV's
+# cv2.imread/imwrite (the only image I/O this app uses) cannot decode or
+# encode GIF on 4.10 or 4.11, so offering it would silently fail. WEBP works
+# via the libwebp bundled with opencv-python.
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".bmp", ".webp")
+VIDEO_EXTENSIONS = (".mp4", ".mkv")
+
 file_types = [
-    ("Image", ("*.png", "*.jpg", "*.jpeg", "*.gif", "*.bmp", "*.webp")),
-    ("Video", ("*.mp4", "*.mkv")),
+    ("Image", tuple(f"*{ext}" for ext in IMAGE_EXTENSIONS)),
+    ("Video", tuple(f"*{ext}" for ext in VIDEO_EXTENSIONS)),
 ]
 
 # Face Mapping Data

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -6,18 +6,13 @@ from typing import List, Dict, Any
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 WORKFLOW_DIR = os.path.join(ROOT_DIR, "workflow")
 
-# Canonical media extensions, defined once so file dialogs, file_types and
+# Canonical media extensions, defined once so the file dialogs and
 # has_image_extension never drift. GIF is intentionally excluded: OpenCV's
 # cv2.imread/imwrite (the only image I/O this app uses) cannot decode or
 # encode GIF on 4.10 or 4.11, so offering it would silently fail. WEBP works
 # via the libwebp bundled with opencv-python.
 IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".bmp", ".webp")
 VIDEO_EXTENSIONS = (".mp4", ".mkv")
-
-file_types = [
-    ("Image", tuple(f"*{ext}" for ext in IMAGE_EXTENSIONS)),
-    ("Video", tuple(f"*{ext}" for ext in VIDEO_EXTENSIONS)),
-]
 
 # Face Mapping Data
 source_target_map: List[Dict[str, Any]] = [] # Stores detailed map for image/video processing

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -244,6 +244,9 @@ _IMAGE_FILE_FILTER = "Images (" + " ".join(
 _MEDIA_FILE_FILTER = "Media (" + " ".join(
     f"*{ext}" for ext in (*modules.globals.IMAGE_EXTENSIONS, *modules.globals.VIDEO_EXTENSIONS)
 ) + ")"
+_VIDEO_FILE_FILTER = "Videos (" + " ".join(
+    f"*{ext}" for ext in modules.globals.VIDEO_EXTENSIONS
+) + ")"
 
 
 # ─── image utilities ─────────────────────────────────────────────────────
@@ -900,7 +903,7 @@ class MainWindow(QMainWindow):
             path, _f = QFileDialog.getSaveFileName(
                 self, _("save video output file"),
                 os.path.join(_RECENT_OUTPUT_DIR or "", "output.mp4"),
-                "Videos (*.mp4 *.mkv)",
+                _VIDEO_FILE_FILTER,
             )
         else:
             return

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -236,6 +236,15 @@ _RECENT_SOURCE_DIR: Optional[str] = None
 _RECENT_TARGET_DIR: Optional[str] = None
 _RECENT_OUTPUT_DIR: Optional[str] = None
 
+# QFileDialog filter strings, built from the canonical extension sets in
+# globals so every dialog stays in sync (no hand-copied lists to drift).
+_IMAGE_FILE_FILTER = "Images (" + " ".join(
+    f"*{ext}" for ext in modules.globals.IMAGE_EXTENSIONS
+) + ")"
+_MEDIA_FILE_FILTER = "Media (" + " ".join(
+    f"*{ext}" for ext in (*modules.globals.IMAGE_EXTENSIONS, *modules.globals.VIDEO_EXTENSIONS)
+) + ")"
+
 
 # ─── image utilities ─────────────────────────────────────────────────────
 
@@ -733,7 +742,7 @@ class MainWindow(QMainWindow):
         path, _filter = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
+            _IMAGE_FILE_FILTER,
         )
         if path and is_image(path):
             modules.globals.source_path = path
@@ -754,7 +763,7 @@ class MainWindow(QMainWindow):
         path, _filter = QFileDialog.getOpenFileName(
             self, _("select an target image or video"),
             _RECENT_TARGET_DIR or "",
-            "Media (*.png *.jpg *.jpeg *.gif *.bmp *.webp *.mp4 *.mkv)",
+            _MEDIA_FILE_FILTER,
         )
         if not path:
             return
@@ -885,7 +894,7 @@ class MainWindow(QMainWindow):
             path, _f = QFileDialog.getSaveFileName(
                 self, _("save image output file"),
                 os.path.join(_RECENT_OUTPUT_DIR or "", "output.png"),
-                "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
+                _IMAGE_FILE_FILTER,
             )
         elif is_video(modules.globals.target_path):
             path, _f = QFileDialog.getSaveFileName(
@@ -1333,7 +1342,7 @@ class MapperDialog(QDialog):
         path, _f = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
+            _IMAGE_FILE_FILTER,
         )
         if not path:
             return
@@ -1438,7 +1447,7 @@ class LiveMapperDialog(QDialog):
         path, _f = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
+            _IMAGE_FILE_FILTER,
         )
         if not path:
             return

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -733,7 +733,7 @@ class MainWindow(QMainWindow):
         path, _filter = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp)",
+            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
         )
         if path and is_image(path):
             modules.globals.source_path = path
@@ -754,7 +754,7 @@ class MainWindow(QMainWindow):
         path, _filter = QFileDialog.getOpenFileName(
             self, _("select an target image or video"),
             _RECENT_TARGET_DIR or "",
-            "Media (*.png *.jpg *.jpeg *.gif *.bmp *.mp4 *.mkv)",
+            "Media (*.png *.jpg *.jpeg *.gif *.bmp *.webp *.mp4 *.mkv)",
         )
         if not path:
             return
@@ -885,7 +885,7 @@ class MainWindow(QMainWindow):
             path, _f = QFileDialog.getSaveFileName(
                 self, _("save image output file"),
                 os.path.join(_RECENT_OUTPUT_DIR or "", "output.png"),
-                "Images (*.png *.jpg *.jpeg *.bmp)",
+                "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
             )
         elif is_video(modules.globals.target_path):
             path, _f = QFileDialog.getSaveFileName(
@@ -1333,7 +1333,7 @@ class MapperDialog(QDialog):
         path, _f = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp)",
+            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
         )
         if not path:
             return
@@ -1438,7 +1438,7 @@ class LiveMapperDialog(QDialog):
         path, _f = QFileDialog.getOpenFileName(
             self, _("select an source image"),
             _RECENT_SOURCE_DIR or "",
-            "Images (*.png *.jpg *.jpeg *.gif *.bmp)",
+            "Images (*.png *.jpg *.jpeg *.gif *.bmp *.webp)",
         )
         if not path:
             return

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -262,11 +262,14 @@ def clean_temp(target_path: str) -> None:
 
 
 def has_image_extension(image_path: str) -> bool:
-    return image_path.lower().endswith(("png", "jpg", "jpeg"))
+    return image_path.lower().endswith(("png", "jpg", "jpeg", "gif", "bmp", "webp"))
 
 
 def is_image(image_path: str) -> bool:
     if image_path and os.path.isfile(image_path):
+        # Extension check first — Windows mimetypes doesn't always register webp
+        if has_image_extension(image_path):
+            return True
         mimetype, _ = mimetypes.guess_type(image_path)
         return bool(mimetype and mimetype.startswith("image/"))
     return False

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -262,7 +262,9 @@ def clean_temp(target_path: str) -> None:
 
 
 def has_image_extension(image_path: str) -> bool:
-    return image_path.lower().endswith(("png", "jpg", "jpeg", "gif", "bmp", "webp"))
+    # splitext so only the real extension counts (e.g. "photo.png.bak" is not
+    # an image); the set is centralized in globals to stay in sync with dialogs.
+    return os.path.splitext(image_path)[1].lower() in modules.globals.IMAGE_EXTENSIONS
 
 
 def is_image(image_path: str) -> bool:


### PR DESCRIPTION
Adds WEBP as a supported source-image format. Re-submission of #1831 (closed); branch is the same, rebuilt against current `main` with the earlier review feedback applied.

## What
- WEBP source images now load and swap correctly, decoded via the libwebp bundled with opencv-python.

## Review feedback addressed
- **GIF dropped** — OpenCV's `imread`/`imwrite` can't decode or encode GIF on 4.10/4.11, so offering it would silently fail; it's excluded instead.
- **Centralized extension lists** — `IMAGE_EXTENSIONS`/`VIDEO_EXTENSIONS` are defined once in `globals.py`; the video save-dialog filter is built from `VIDEO_EXTENSIONS` (`_VIDEO_FILE_FILTER`) so the dialogs and `has_image_extension` can't drift.
- Removed the dead `file_types` list (verified unused in both fork and upstream).

Ruff gate (`E701,E711,E712,F401,F541`) clean; live-tested load + swap.

## Summary by Sourcery

Add WEBP as a supported image format and centralize media file extension handling across globals and UI dialogs.

New Features:
- Support loading WEBP images as valid source images by recognizing their extensions and integrating with existing image detection logic.

Enhancements:
- Centralize canonical image and video extension lists in globals and reuse them to build QFileDialog filters, keeping UI dialogs and extension checks in sync.
- Remove the unused file_types definition in globals to simplify media type configuration.