### PR TITLE
fix: release CUDA tensors in _fast_paste_back to prevent GPU memory exhaustion

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -59,6 +59,7 @@ def parse_args() -> None:
     program.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
     program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=[suggest_default_execution_provider()], choices=suggest_execution_providers(), nargs='+')
     program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
+    program.add_argument('--cache-clean-interval', help='frames between CUDA cache flushes (0 to disable)', dest='cache_clean_interval', type=int, default=50)
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
 
     # register deprecated args
@@ -88,6 +89,7 @@ def parse_args() -> None:
     modules.globals.max_memory = args.max_memory
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
+    modules.globals.cache_clean_interval = max(0, args.cache_clean_interval)
     modules.globals.lang = args.lang
 
     #for ENHANCER tumblers:

--- a/modules/core.py
+++ b/modules/core.py
@@ -182,6 +182,10 @@ def limit_resources() -> None:
 
 def release_resources() -> None:
     if 'CUDAExecutionProvider' in modules.globals.execution_providers:
+        # Import torch at runtime rather than relying on a module-level
+        # HAS_TORCH flag. This ensures the CUDA cache is flushed even when
+        # PyTorch is loaded after this module, and avoids import-order issues
+        # that could prevent cleanup on shutdown (issue #1868).
         try:
             import torch
             torch.cuda.empty_cache()

--- a/modules/core.py
+++ b/modules/core.py
@@ -188,7 +188,8 @@ def release_resources() -> None:
         # that could prevent cleanup on shutdown (issue #1868).
         try:
             import torch
-            torch.cuda.empty_cache()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
         except ImportError:
             pass
 

--- a/modules/core.py
+++ b/modules/core.py
@@ -181,8 +181,12 @@ def limit_resources() -> None:
 
 
 def release_resources() -> None:
-    if 'CUDAExecutionProvider' in modules.globals.execution_providers and HAS_TORCH:
-        torch.cuda.empty_cache()
+    if 'CUDAExecutionProvider' in modules.globals.execution_providers:
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except ImportError:
+            pass
 
 
 def pre_check() -> bool:

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -57,6 +57,9 @@ face_swapper_enabled: bool = True # General toggle for the swapper processor
 opacity: float = 1.0              # Blend factor for the swapped face (0.0-1.0)
 sharpness: float = 0.0            # Sharpness enhancement for swapped face (0.0-1.0+)
 
+# Cache clean interval (frames between CUDA cache flushes, issue #1868)
+cache_clean_interval: int = 50
+
 # Mouth Mask Options
 mouth_mask: bool = False           # Enable mouth area masking/pasting
 show_mouth_mask_box: bool = False  # Visualize the mouth mask area (for debugging)

--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -30,11 +30,6 @@ ALLOWED_PROCESSORS = {
     'face_enhancer_gpen512'
 }
 
-# How often (in frames) to flush Python GC and CUDA cache during
-# in-memory video processing. Prevents VRAM accumulation when both
-# ONNX Runtime and PyTorch share the same GPU device (issue #1868).
-CACHE_CLEAN_INTERVAL = 50
-
 def load_frame_processor_module(frame_processor: str) -> Any:
     if frame_processor not in ALLOWED_PROCESSORS:
         print(f"Frame processor {frame_processor} is not allowed")
@@ -395,7 +390,9 @@ def _run_pipe_pipeline(
                 # long videos. ONNX Runtime (insightface) and PyTorch share the
                 # same GPU device; without explicit cleanup, accumulated tensor
                 # allocations from both frameworks cause CUBLAS errors (issue #1868).
-                if processed_count % CACHE_CLEAN_INTERVAL == 0:
+                # Interval is configurable via --cache-clean-interval (0 = disabled).
+                interval = modules.globals.cache_clean_interval
+                if interval > 0 and processed_count % interval == 0:
                     gc.collect()
                     if _torch is not None and _torch.cuda.is_available():
                         _torch.cuda.empty_cache()

--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -377,6 +377,16 @@ def _run_pipe_pipeline(
                 processed_count += 1
                 progress.update(1)
 
+                if processed_count % 50 == 0:
+                    import gc
+                    gc.collect()
+                    try:
+                        import torch
+                        if torch.cuda.is_available():
+                            torch.cuda.empty_cache()
+                    except ImportError:
+                        pass
+
             detect_executor.shutdown(wait=True)
 
         # Graceful shutdown

--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -377,6 +377,10 @@ def _run_pipe_pipeline(
                 processed_count += 1
                 progress.update(1)
 
+                # Periodically flush CUDA cache to prevent VRAM exhaustion over
+                # long videos. ONNX Runtime (insightface) and PyTorch share the
+                # same GPU device; without explicit cleanup, accumulated tensor
+                # allocations from both frameworks cause CUBLAS errors (issue #1868).
                 if processed_count % 50 == 0:
                     import gc
                     gc.collect()

--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import gc
 import importlib
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
@@ -28,6 +29,11 @@ ALLOWED_PROCESSORS = {
     'face_enhancer_gpen256',
     'face_enhancer_gpen512'
 }
+
+# How often (in frames) to flush Python GC and CUDA cache during
+# in-memory video processing. Prevents VRAM accumulation when both
+# ONNX Runtime and PyTorch share the same GPU device (issue #1868).
+CACHE_CLEAN_INTERVAL = 50
 
 def load_frame_processor_module(frame_processor: str) -> Any:
     if frame_processor not in ALLOWED_PROCESSORS:
@@ -332,6 +338,14 @@ def _run_pipe_pipeline(
                 'mode': 'in-memory',
             })
 
+            # Lazily import torch here (it may not be installed) so the
+            # periodic CUDA cache flush in the loop below can use it.
+            _torch = None
+            try:
+                import torch as _torch
+            except ImportError:
+                pass
+
             # Pipelined detection: while processing frame N (swap on
             # ANE), start detecting the face in the next frame
             # (detection on GPU).  They use different hardware units
@@ -381,15 +395,10 @@ def _run_pipe_pipeline(
                 # long videos. ONNX Runtime (insightface) and PyTorch share the
                 # same GPU device; without explicit cleanup, accumulated tensor
                 # allocations from both frameworks cause CUBLAS errors (issue #1868).
-                if processed_count % 50 == 0:
-                    import gc
+                if processed_count % CACHE_CLEAN_INTERVAL == 0:
                     gc.collect()
-                    try:
-                        import torch
-                        if torch.cuda.is_available():
-                            torch.cuda.empty_cache()
-                    except ImportError:
-                        pass
+                    if _torch is not None and _torch.cuda.is_available():
+                        _torch.cuda.empty_cache()
 
             detect_executor.shutdown(wait=True)
 

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -487,6 +487,7 @@ def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, 
         tgt_t = torch.from_numpy(target_crop).float().cuda()
         blended = (mask_t * fake_t + (1.0 - mask_t) * tgt_t).to(torch.uint8).cpu().numpy()
         target_img[y1p:y2p, x1p:x2p] = blended
+        del mask_t, fake_t, tgt_t, blended
     else:
         # Fused uint8 blend via cv2 SIMD — no float32 round-trip.
         # Measured ~7-8× faster than the old numpy float32 path on a 1000×1000 crop.

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -490,7 +490,8 @@ def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, 
         # Explicitly release CUDA tensor references. Without this, tensors persist
         # until garbage collection, accumulating across frames and exhausting VRAM
         # when both ONNX Runtime and PyTorch share the same GPU (issue #1868).
-        del mask_t, fake_t, tgt_t, blended
+        # `blended` is a CPU numpy array and does not need explicit cleanup.
+        del mask_t, fake_t, tgt_t
     else:
         # Fused uint8 blend via cv2 SIMD — no float32 round-trip.
         # Measured ~7-8× faster than the old numpy float32 path on a 1000×1000 crop.

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -487,6 +487,9 @@ def _fast_paste_back(target_img: Frame, bgr_fake: np.ndarray, aimg: np.ndarray, 
         tgt_t = torch.from_numpy(target_crop).float().cuda()
         blended = (mask_t * fake_t + (1.0 - mask_t) * tgt_t).to(torch.uint8).cpu().numpy()
         target_img[y1p:y2p, x1p:x2p] = blended
+        # Explicitly release CUDA tensor references. Without this, tensors persist
+        # until garbage collection, accumulating across frames and exhausting VRAM
+        # when both ONNX Runtime and PyTorch share the same GPU (issue #1868).
         del mask_t, fake_t, tgt_t, blended
     else:
         # Fused uint8 blend via cv2 SIMD — no float32 round-trip.


### PR DESCRIPTION
Fixes #1868

## Summary

GPU memory leak in _fast_paste_back causes CUBLAS_STATUS_NOT_INITIALIZED crash when processing long videos (>500 frames) with --execution-provider cuda.

## Root Cause

_fast_paste_back creates PyTorch CUDA intermediate tensors (mask_t, ake_t, 	gt_t, lended) that are never explicitly freed. ONNX Runtime (insightface) and PyTorch share the same GPU. Over hundreds of frames, the unreleased tensors accumulate, exhausting VRAM and corrupting the CUDA context.

## Changes

### modules/processors/frame/face_swapper.py
- Add del mask_t, fake_t, tgt_t, blended after blend to immediately release CUDA tensor references

### modules/processors/frame/core.py
- Add gc.collect() + 	orch.cuda.empty_cache() every 50 frames in _run_pipe_pipeline

### modules/core.py
- Make elease_resources() attempt 	orch.cuda.empty_cache() via runtime import instead of module-level HAS_TORCH flag

## Benchmark

Tested on RTX 2060 6GB, 1129 frames (1080p, 37.6s video):
- **Before fix:** Crash at ~300-500 frames with CUBLAS error
- **After fix:** Completed 1129 frames in 126.8s (~8.9 fps) without errors

## Summary by Sourcery

Address GPU memory exhaustion during CUDA-based frame processing by releasing intermediate tensors and proactively clearing CUDA caches.

Bug Fixes:
- Free intermediate CUDA tensors after fast paste-back blending to prevent VRAM accumulation and CUDA context corruption.
- Periodically trigger Python garbage collection and CUDA cache clearing during frame pipeline processing to reduce long-run memory growth.
- Ensure resource release attempts CUDA cache clearing via a safe runtime import, even when PyTorch was not imported at module load time.