### PR TITLE
feat: auto-skip face_swapper when no source face is provided

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -206,6 +206,16 @@ def start() -> None:
     
     start_time = time.time()
     
+    # When no source is provided but an enhancer is active, automatically
+    # remove the face_swapper and run in face-restoration mode (#1867).
+    if modules.globals.source_path is None:
+        enhancers = {'face_enhancer', 'face_enhancer_gpen256', 'face_enhancer_gpen512'}
+        if enhancers & set(modules.globals.frame_processors):
+            modules.globals.frame_processors = [
+                p for p in modules.globals.frame_processors if p != 'face_swapper'
+            ]
+            update_status('No source face — running in face-restoration mode (enhancement only).')
+    
     for frame_processor in get_frame_processors_modules(modules.globals.frame_processors):
         if not frame_processor.pre_start():
             return


### PR DESCRIPTION
When running with no source image (-s) but an enhancer enabled, the face swapper has nothing to swap. This PR auto-detects this case and removes face_swapper from the pipeline, allowing the enhancer to run in face-restoration mode.

Fixes #1867

## Summary by Sourcery

Improve GPU memory handling during frame processing and refine CUDA cache cleanup behavior across the pipeline.

Enhancements:
- Add periodic Python GC and CUDA cache flushing during in-memory video processing to reduce VRAM accumulation for long runs.
- Release temporary CUDA tensors explicitly after face blending to avoid per-frame VRAM growth when using the face swapper.
- Change resource release logic to import PyTorch at runtime and conditionally flush the CUDA cache, avoiding import-order issues.