### PR TITLE
fix: resolve OpenVINO DLL loading on Windows for OpenVINOExecutionProvider

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -132,9 +132,9 @@ def suggest_max_memory() -> int:
 
 
 def suggest_default_execution_provider() -> str:
-    """Pick the best available provider: cuda > rocm > coreml > dml > cpu."""
+    """Pick the best available provider: cuda > rocm > coreml > openvino > dml > cpu."""
     available = encode_execution_providers(onnxruntime.get_available_providers())
-    for pref in ('cuda', 'rocm', 'coreml', 'dml'):
+    for pref in ('cuda', 'rocm', 'coreml', 'openvino', 'dml'):
         if pref in available:
             return pref
     return 'cpu'
@@ -157,6 +157,8 @@ def suggest_execution_threads() -> int:
         return 1
     if 'CUDAExecutionProvider' in modules.globals.execution_providers:
         return 2
+    if 'OpenVINOExecutionProvider' in modules.globals.execution_providers:
+        return 1
     
     # For CPU execution, use most cores but leave some for system
     return max(4, min(cpu_count - 2, 16))

--- a/modules/platform_info.py
+++ b/modules/platform_info.py
@@ -40,6 +40,7 @@ ONNX_PROVIDERS: List[str] = _detect_onnx_providers()
 HAS_CUDA_PROVIDER: bool = "CUDAExecutionProvider" in ONNX_PROVIDERS
 HAS_COREML_PROVIDER: bool = "CoreMLExecutionProvider" in ONNX_PROVIDERS
 HAS_DML_PROVIDER: bool = "DmlExecutionProvider" in ONNX_PROVIDERS
+HAS_OPENVINO_PROVIDER: bool = "OpenVINOExecutionProvider" in ONNX_PROVIDERS
 
 
 def camera_backends() -> List[Tuple[int, int]]:
@@ -65,6 +66,8 @@ def accelerator_label() -> str:
         return "CoreML (Apple Neural Engine)"
     if HAS_COREML_PROVIDER:
         return "CoreML"
+    if HAS_OPENVINO_PROVIDER:
+        return "OpenVINO (Intel)"
     if HAS_DML_PROVIDER:
         return "DirectML"
     return "CPU"

--- a/modules/processors/frame/_onnx_enhancer.py
+++ b/modules/processors/frame/_onnx_enhancer.py
@@ -50,6 +50,14 @@ def build_provider_config(providers=None):
                     "AllowLowPrecisionAccumulationOnGPU": 1,
                 },
             ))
+        elif p == "OpenVINOExecutionProvider":
+            # Prefer Intel GPU with FP16 precision when available.
+            # NB: GPU_FP16 is deprecated since OpenVINO 2025.4 — use
+            # device_type="GPU" + precision="FP16" instead.
+            config.append((
+                "OpenVINOExecutionProvider",
+                {"device_type": "GPU", "precision": "FP16"},
+            ))
         else:
             config.append(p)
     return config

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -270,6 +270,11 @@ def get_face_swapper() -> Any:
                         # Use bare provider — ONNX Runtime defaults are
                         # fastest on modern GPUs (Blackwell/sm_120).
                         providers_config.append(p)
+                    elif p == "OpenVINOExecutionProvider":
+                        providers_config.append((
+                            "OpenVINOExecutionProvider",
+                            {"device_type": "GPU", "precision": "FP16"},
+                        ))
                     else:
                         providers_config.append(p)
                 FACE_SWAPPER = insightface.model_zoo.get_model(

--- a/run.py
+++ b/run.py
@@ -31,6 +31,17 @@ if sys.platform == "win32":
             except (OSError, AttributeError):
                 pass
 
+    # On Windows, register OpenVINO DLL directories so onnxruntime's
+    # OpenVINOExecutionProvider can find openvino.dll.  This must happen
+    # before any ONNX InferenceSession is created.
+    try:
+        from onnxruntime.tools.add_openvino_win_libs import (  # type: ignore[import-untyped]  # noqa: E501
+            add_openvino_libs_to_path,
+        )
+        add_openvino_libs_to_path()
+    except (ImportError, FileNotFoundError):
+        pass  # OpenVINO not installed — no-op
+
 # On Linux, pre-load NVIDIA shared libraries (cuDNN, cuBLAS, nvrtc...) shipped
 # inside the venv via pip wheels (nvidia-cudnn-cu12, etc.). LD_LIBRARY_PATH
 # cannot be set after Python starts, so we use ctypes.CDLL with RTLD_GLOBAL


### PR DESCRIPTION
## Description

Fixes the `openvino.dll` loading issue that prevented ONNX Runtime's OpenVINOExecutionProvider from working on Windows.

### Root Cause

`onnxruntime_providers_openvino.dll` depends on `openvino.dll`, but the OpenVINO Python package installs `openvino.dll` under `site-packages/openvino/libs/` — a directory not on the system `PATH`. When ONNX Runtime attempts to create a session with `OpenVINOExecutionProvider`, the DLL load fails silently and falls back to CPU.

### Changes

| File | Change |
|------|--------|
| `run.py` | Call `add_openvino_libs_to_path()` from `onnxruntime.tools.add_openvino_win_libs` before any ONNX session is created (graceful no-op when OpenVINO is absent) |
| `modules/platform_info.py` | Detect `OpenVINOExecutionProvider` in available providers; show "OpenVINO (Intel)" in the banner |
| `modules/core.py` | Add `openvino` to provider priority list (`cuda > rocm > coreml > openvino > dml > cpu`); set thread hint to 1 for OpenVINO EP |
| `modules/processors/frame/_onnx_enhancer.py` | Configure `OpenVINOExecutionProvider` with `device_type: GPU, precision: FP16` for best performance |
| `modules/processors/frame/face_swapper.py` | Same GPU FP16 provider config applied to the face swap model |

### Performance

`inswapper_128.onnx` benchmark on Intel GPU + OpenVINO:

| Provider | Device | Latency | FPS |
|----------|--------|---------|-----|
| OpenVINO EP | GPU FP16 | **76 ms** | **13.1 FPS** |
| CPU EP (fallback) | CPU | 786 ms | 1.3 FPS |

### Testing

- [x] `--execution-provider openvino` listed in `--help`
- [x] Banner shows `accelerator: OpenVINO (Intel)`
- [x] Face swapper model loads with `OpenVINOExecutionProvider` active
- [x] Inference produces correct output shape `(1, 3, 128, 128)`
- [x] Registration is a no-op when OpenVINO is not installed (try/except)

## Summary by Sourcery

Ensure OpenVINOExecutionProvider works and is preferred when available, particularly on Windows with Intel GPUs.

New Features:
- Detect and label OpenVINOExecutionProvider in platform info, showing it as "OpenVINO (Intel)" in the accelerator banner.

Bug Fixes:
- Register OpenVINO DLL directories on Windows at startup so onnxruntime can successfully load OpenVINOExecutionProvider instead of silently falling back to CPU.

Enhancements:
- Prioritize OpenVINO ahead of DirectML in the default execution provider selection and set a single-thread hint when OpenVINOExecutionProvider is active.
- Configure OpenVINOExecutionProvider with GPU FP16 settings for ONNX-based frame enhancement and face swapping models to improve performance.