### PR TITLE
docs: update manual installation to use shallow clone (#1866)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This is more likely to work on your computer but will be slower as it utilizes t
 **2. Clone the Repository**
 
 ```bash
-git clone https://github.com/hacksider/Deep-Live-Cam.git
+git clone --depth 1 https://github.com/hacksider/Deep-Live-Cam.git
 cd Deep-Live-Cam
 ```
 


### PR DESCRIPTION
Closes #1866 

### Description
Updated the manual installation instructions in `README.md` to use a shallow clone (`--depth 1`).

### Checklist
- [x] Documentation-only change (Exempt from runtime/stability testing)

## Summary by Sourcery

Documentation:
- Change the README manual installation instructions to use a shallow Git clone (`git clone --depth 1 …`).