### PR TITLE
fix: scope PyTorch CUDA cache cleanup to CUDA pipelines

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -26,7 +26,7 @@ except ImportError:
 import modules.globals
 import modules.metadata
 import modules.ui as ui
-from modules.processors.frame.core import get_frame_processors_modules, process_video_in_memory
+from modules.processors.frame.core import CUDA_EXECUTION_PROVIDER, get_frame_processors_modules, process_video_in_memory
 from modules.utilities import has_image_extension, is_image, is_video, detect_fps, create_video, extract_frames, get_temp_frame_paths, restore_audio, create_temp, move_temp, clean_temp, normalize_output_path
 
 if HAS_TORCH and 'ROCMExecutionProvider' in modules.globals.execution_providers:
@@ -181,8 +181,16 @@ def limit_resources() -> None:
 
 
 def release_resources() -> None:
-    if 'CUDAExecutionProvider' in modules.globals.execution_providers and HAS_TORCH:
-        torch.cuda.empty_cache()
+    if CUDA_EXECUTION_PROVIDER in modules.globals.execution_providers:
+        # Avoid the module-level availability snapshot: PyTorch may be loaded
+        # after this module and still have CUDA cache blocks to release.
+        try:
+            import torch
+        except ImportError:
+            return
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
 
 def pre_check() -> bool:

--- a/modules/processors/frame/core.py
+++ b/modules/processors/frame/core.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import gc
 import importlib
 from concurrent.futures import ThreadPoolExecutor
 from types import ModuleType
@@ -28,6 +29,72 @@ ALLOWED_PROCESSORS = {
     'face_enhancer_gpen256',
     'face_enhancer_gpen512'
 }
+
+CUDA_EXECUTION_PROVIDER = 'CUDAExecutionProvider'
+CUDA_CACHE_CLEAN_INTERVAL = 50
+_CUDA_GC_COLLECT_INTERVAL = CUDA_CACHE_CLEAN_INTERVAL * 10
+_BYTES_PER_MEBIBYTE = 1024 * 1024
+
+
+def _get_cuda_torch() -> ModuleType | None:
+    """Return PyTorch only when this pipeline is using CUDA."""
+    if CUDA_EXECUTION_PROVIDER not in modules.globals.execution_providers:
+        return None
+
+    try:
+        import torch
+        return torch if torch.cuda.is_available() else None
+    except (ImportError, RuntimeError):
+        return None
+
+
+def _format_cuda_memory(memory_bytes: int) -> str:
+    return f'{memory_bytes / _BYTES_PER_MEBIBYTE:.1f} MiB'
+
+
+def _get_cuda_memory_stats(torch_module: ModuleType) -> tuple[int, int] | None:
+    try:
+        return (
+            torch_module.cuda.memory_allocated(),
+            torch_module.cuda.memory_reserved(),
+        )
+    except RuntimeError:
+        return None
+
+
+def _report_cuda_cache_cleanup(message: str) -> None:
+    # Import lazily to avoid the core -> frame core circular import at module load.
+    from modules.core import update_status
+    update_status(message)
+
+
+def _clear_cuda_cache(torch_module: ModuleType, frame_number: int) -> None:
+    """Release unused PyTorch cache blocks and report the observed change."""
+    memory_before = _get_cuda_memory_stats(torch_module)
+
+    # Reference-counted tensor temporaries are released at function return, so
+    # a full cyclic-GC sweep is only needed occasionally.
+    if frame_number % _CUDA_GC_COLLECT_INTERVAL == 0:
+        gc.collect()
+
+    try:
+        torch_module.cuda.empty_cache()
+    except RuntimeError:
+        return
+
+    memory_after = _get_cuda_memory_stats(torch_module)
+    if memory_before is None or memory_after is None:
+        return
+
+    allocated_before, reserved_before = memory_before
+    allocated_after, reserved_after = memory_after
+    _report_cuda_cache_cleanup(
+        f'CUDA cache cleanup at frame {frame_number}: '
+        f'allocated {_format_cuda_memory(allocated_before)} -> '
+        f'{_format_cuda_memory(allocated_after)}, reserved '
+        f'{_format_cuda_memory(reserved_before)} -> '
+        f'{_format_cuda_memory(reserved_after)}'
+    )
 
 def load_frame_processor_module(frame_processor: str) -> Any:
     if frame_processor not in ALLOWED_PROCESSORS:
@@ -320,6 +387,7 @@ def _run_pipe_pipeline(
         return False
 
     processed_count = 0
+    cuda_torch = _get_cuda_torch()
     bar_fmt = ('{l_bar}{bar}| {n_fmt}/{total_fmt} '
                '[{elapsed}<{remaining}, {rate_fmt}{postfix}]')
 
@@ -376,6 +444,15 @@ def _run_pipe_pipeline(
                 writer.stdin.write(frame.tobytes())
                 processed_count += 1
                 progress.update(1)
+
+                # PyTorch releases tensors when their references disappear, but
+                # retains reusable blocks in its CUDA cache. Periodically return
+                # unused blocks to the driver so ONNX Runtime can allocate them.
+                if (
+                    cuda_torch is not None
+                    and processed_count % CUDA_CACHE_CLEAN_INTERVAL == 0
+                ):
+                    _clear_cuda_cache(cuda_torch, processed_count)
 
             detect_executor.shutdown(wait=True)
 

--- a/tests/test_cuda_memory_management.py
+++ b/tests/test_cuda_memory_management.py
@@ -1,0 +1,175 @@
+import builtins
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+
+def _frame_core_import_stubs():
+    return {
+        'cv2': types.SimpleNamespace(
+            IMREAD_COLOR=1,
+            imread=lambda *_args, **_kwargs: None,
+            imdecode=lambda *_args, **_kwargs: None,
+            imencode=lambda *_args, **_kwargs: (
+                True,
+                types.SimpleNamespace(tofile=lambda *_a, **_k: None),
+            ),
+        ),
+        'numpy': types.SimpleNamespace(uint8=object),
+        'tqdm': types.SimpleNamespace(tqdm=lambda *args, **_kwargs: args[0]),
+        'modules.face_analyser': types.SimpleNamespace(
+            get_one_face=lambda *_args, **_kwargs: None,
+        ),
+    }
+
+
+def _unload_modules():
+    for module_name in tuple(sys.modules):
+        if module_name == 'modules' or module_name.startswith('modules.'):
+            sys.modules.pop(module_name)
+
+
+class FakeCuda:
+    def __init__(self, allocated, reserved, is_available=True):
+        self.allocated = list(allocated)
+        self.reserved = list(reserved)
+        self.is_available_value = is_available
+        self.empty_cache_calls = 0
+
+    def is_available(self):
+        return self.is_available_value
+
+    def memory_allocated(self):
+        return self.allocated.pop(0)
+
+    def memory_reserved(self):
+        return self.reserved.pop(0)
+
+    def empty_cache(self):
+        self.empty_cache_calls += 1
+
+
+class CudaMemoryManagementTests(unittest.TestCase):
+    def setUp(self):
+        self.existing_modules = {
+            name: module
+            for name, module in sys.modules.items()
+            if name == 'modules' or name.startswith('modules.')
+        }
+        _unload_modules()
+        self.import_stubs = patch.dict(sys.modules, _frame_core_import_stubs())
+        self.import_stubs.start()
+        self.frame_core = importlib.import_module('modules.processors.frame.core')
+        self.execution_providers = self.frame_core.modules.globals.execution_providers
+
+    def tearDown(self):
+        self.frame_core.modules.globals.execution_providers = self.execution_providers
+        _unload_modules()
+        self.import_stubs.stop()
+        sys.modules.update(self.existing_modules)
+
+    def _use_cuda_provider(self):
+        self.frame_core.modules.globals.execution_providers = ['CUDAExecutionProvider']
+
+    def test_does_not_import_torch_without_cuda_execution_provider(self):
+        self.frame_core.modules.globals.execution_providers = ['CPUExecutionProvider']
+
+        with patch('builtins.__import__', side_effect=AssertionError('torch import')):
+            self.assertIsNone(self.frame_core._get_cuda_torch())
+
+    def test_returns_none_when_torch_import_fails(self):
+        self._use_cuda_provider()
+        original_import = builtins.__import__
+
+        def import_without_torch(name, *args, **kwargs):
+            if name == 'torch':
+                raise ImportError('torch is unavailable')
+            return original_import(name, *args, **kwargs)
+
+        with patch('builtins.__import__', side_effect=import_without_torch):
+            self.assertIsNone(self.frame_core._get_cuda_torch())
+
+    def test_returns_torch_only_when_cuda_is_available(self):
+        fake_cuda = FakeCuda([], [])
+        fake_torch = types.SimpleNamespace(cuda=fake_cuda)
+        self._use_cuda_provider()
+
+        with patch.dict(sys.modules, {'torch': fake_torch}):
+            self.assertIs(self.frame_core._get_cuda_torch(), fake_torch)
+
+    def test_skips_torch_without_an_available_cuda_device(self):
+        fake_cuda = FakeCuda([], [], is_available=False)
+        fake_torch = types.SimpleNamespace(cuda=fake_cuda)
+        self._use_cuda_provider()
+
+        with patch.dict(sys.modules, {'torch': fake_torch}):
+            self.assertIsNone(self.frame_core._get_cuda_torch())
+
+    def test_returns_none_when_cuda_probe_fails(self):
+        fake_cuda = types.SimpleNamespace(
+            is_available=Mock(side_effect=RuntimeError('CUDA probing failed')),
+        )
+        self._use_cuda_provider()
+
+        with patch.dict(sys.modules, {'torch': types.SimpleNamespace(cuda=fake_cuda)}):
+            self.assertIsNone(self.frame_core._get_cuda_torch())
+
+    def test_returns_none_when_memory_stats_fail(self):
+        fake_cuda = types.SimpleNamespace(
+            memory_allocated=Mock(side_effect=RuntimeError('CUDA stats failed')),
+            memory_reserved=Mock(),
+        )
+
+        self.assertIsNone(
+            self.frame_core._get_cuda_memory_stats(types.SimpleNamespace(cuda=fake_cuda)),
+        )
+
+    def test_reports_allocated_and_reserved_memory_after_cache_cleanup(self):
+        mebibyte = 1024 * 1024
+        fake_cuda = FakeCuda([6 * mebibyte, 4 * mebibyte], [10 * mebibyte, 5 * mebibyte])
+        fake_torch = types.SimpleNamespace(cuda=fake_cuda)
+
+        with patch.object(self.frame_core.gc, 'collect') as collect, patch.object(
+            self.frame_core, '_report_cuda_cache_cleanup',
+        ) as report:
+            self.frame_core._clear_cuda_cache(fake_torch, 50)
+
+        collect.assert_not_called()
+        self.assertEqual(fake_cuda.empty_cache_calls, 1)
+        report.assert_called_once_with(
+            'CUDA cache cleanup at frame 50: '
+            'allocated 6.0 MiB -> 4.0 MiB, reserved 10.0 MiB -> 5.0 MiB',
+        )
+
+    def test_runs_full_gc_at_the_lower_frequency_interval(self):
+        mebibyte = 1024 * 1024
+        fake_cuda = FakeCuda([6 * mebibyte, 4 * mebibyte], [10 * mebibyte, 5 * mebibyte])
+        fake_torch = types.SimpleNamespace(cuda=fake_cuda)
+
+        with patch.object(self.frame_core.gc, 'collect') as collect, patch.object(
+            self.frame_core, '_report_cuda_cache_cleanup',
+        ):
+            self.frame_core._clear_cuda_cache(
+                fake_torch,
+                self.frame_core._CUDA_GC_COLLECT_INTERVAL,
+            )
+
+        collect.assert_called_once_with()
+
+    def test_ignores_empty_cache_runtime_errors(self):
+        fake_cuda = types.SimpleNamespace(
+            memory_allocated=Mock(return_value=0),
+            memory_reserved=Mock(return_value=0),
+            empty_cache=Mock(side_effect=RuntimeError('CUDA cache unavailable')),
+        )
+
+        with patch.object(self.frame_core, '_report_cuda_cache_cleanup') as report:
+            self.frame_core._clear_cuda_cache(types.SimpleNamespace(cuda=fake_cuda), 50)
+
+        report.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #1868

Supersedes #1869, which GitHub no longer permits reopening.

## What changed
- Load PyTorch, run cleanup, and release its CUDA cache only when CUDAExecutionProvider is active. CPU and CoreML pipelines do not pay this cost.
- Release unused PyTorch cache blocks every 50 frames. Full cyclic garbage collection runs every 500 frames, reducing pauses while retaining periodic cleanup.
- Report memory_allocated() and memory_reserved() before and after each cache release through the existing DLC.CORE status channel. If CUDA memory statistics or cache release fails, processing continues safely.
- Use the same CUDA provider constant for pipeline and shutdown cleanup.

## Validation
- Added 9 focused CUDA-memory tests plus the existing 3 tests: 12 unit tests pass.
- End-to-end CUDA run on RTX 3060 12GB with PyTorch 2.6.0+cu124 and ONNX Runtime CUDAExecutionProvider: completed all 1,129 frames of the supplied 1080x1920, 37.63-second video. Total runtime: 82.50 seconds; in-memory processing and encoding: 80.31 seconds.
- The status logs show allocated memory at 0 MiB before and after cleanup, while reserved cache fell from 88 MiB to 0 MiB at frame 50 and from 258 MiB to 0 MiB at frame 1,100. This confirms the benefit is returning cached blocks to the CUDA driver rather than retaining live local tensors.