### PR TITLE
fix: resolve OpenVINO DLL loading on Windows for OpenVINOExecutionProvider

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -58,7 +58,7 @@ def parse_args() -> None:
     program.add_argument('--live-resizable', help='The live camera frame is resizable', dest='live_resizable', action='store_true', default=False)
     program.add_argument('--max-memory', help='maximum amount of RAM in GB', dest='max_memory', type=int, default=suggest_max_memory())
     program.add_argument('--execution-provider', help='execution provider', dest='execution_provider', default=[suggest_default_execution_provider()], choices=suggest_execution_providers(), nargs='+')
-    program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=suggest_execution_threads())
+    program.add_argument('--execution-threads', help='number of execution threads', dest='execution_threads', type=int, default=None)
     program.add_argument('-v', '--version', action='version', version=f'{modules.metadata.name} {modules.metadata.version}')
 
     # register deprecated args
@@ -89,6 +89,12 @@ def parse_args() -> None:
     modules.globals.execution_providers = decode_execution_providers(args.execution_provider)
     modules.globals.execution_threads = args.execution_threads
     modules.globals.lang = args.lang
+
+    # The argparse default (None) avoids evaluating suggest_execution_threads()
+    # before providers are decoded, and deprecated-arg overrides above may
+    # have already set execution_threads.
+    if modules.globals.execution_threads is None:
+        modules.globals.execution_threads = suggest_execution_threads()
 
     #for ENHANCER tumblers:
     for enhancer_key in ('face_enhancer', 'face_enhancer_gpen256', 'face_enhancer_gpen512'):

--- a/modules/core.py
+++ b/modules/core.py
@@ -132,9 +132,9 @@ def suggest_max_memory() -> int:
 
 
 def suggest_default_execution_provider() -> str:
-    """Pick the best available provider: cuda > rocm > coreml > dml > cpu."""
+    """Pick the best available provider: cuda > rocm > coreml > openvino > dml > cpu."""
     available = encode_execution_providers(onnxruntime.get_available_providers())
-    for pref in ('cuda', 'rocm', 'coreml', 'dml'):
+    for pref in ('cuda', 'rocm', 'coreml', 'openvino', 'dml'):
         if pref in available:
             return pref
     return 'cpu'
@@ -157,6 +157,8 @@ def suggest_execution_threads() -> int:
         return 1
     if 'CUDAExecutionProvider' in modules.globals.execution_providers:
         return 2
+    if 'OpenVINOExecutionProvider' in modules.globals.execution_providers:
+        return 1
     
     # For CPU execution, use most cores but leave some for system
     return max(4, min(cpu_count - 2, 16))

--- a/modules/platform_info.py
+++ b/modules/platform_info.py
@@ -44,7 +44,7 @@ HAS_OPENVINO_PROVIDER: bool = "OpenVINOExecutionProvider" in ONNX_PROVIDERS
 
 # OpenVINO execution-provider config shared by every ONNX session builder.
 # AUTO:GPU,NPU,CPU lets OpenVINO pick the best available device in priority
-# order (Intel GPU → NPU → CPU). 
+# order (Intel GPU → NPU → CPU).
 OPENVINO_PROVIDER_CONFIG = (
     "OpenVINOExecutionProvider",
     {"device_type": "AUTO:GPU,NPU,CPU"},

--- a/modules/platform_info.py
+++ b/modules/platform_info.py
@@ -40,6 +40,7 @@ ONNX_PROVIDERS: List[str] = _detect_onnx_providers()
 HAS_CUDA_PROVIDER: bool = "CUDAExecutionProvider" in ONNX_PROVIDERS
 HAS_COREML_PROVIDER: bool = "CoreMLExecutionProvider" in ONNX_PROVIDERS
 HAS_DML_PROVIDER: bool = "DmlExecutionProvider" in ONNX_PROVIDERS
+HAS_OPENVINO_PROVIDER: bool = "OpenVINOExecutionProvider" in ONNX_PROVIDERS
 
 
 def camera_backends() -> List[Tuple[int, int]]:
@@ -65,6 +66,8 @@ def accelerator_label() -> str:
         return "CoreML (Apple Neural Engine)"
     if HAS_COREML_PROVIDER:
         return "CoreML"
+    if HAS_OPENVINO_PROVIDER:
+        return "OpenVINO (Intel)"
     if HAS_DML_PROVIDER:
         return "DirectML"
     return "CPU"

--- a/modules/platform_info.py
+++ b/modules/platform_info.py
@@ -42,6 +42,14 @@ HAS_COREML_PROVIDER: bool = "CoreMLExecutionProvider" in ONNX_PROVIDERS
 HAS_DML_PROVIDER: bool = "DmlExecutionProvider" in ONNX_PROVIDERS
 HAS_OPENVINO_PROVIDER: bool = "OpenVINOExecutionProvider" in ONNX_PROVIDERS
 
+# OpenVINO execution-provider config shared by every ONNX session builder.
+# AUTO:GPU,NPU,CPU lets OpenVINO pick the best available device in priority
+# order (Intel GPU → NPU → CPU). 
+OPENVINO_PROVIDER_CONFIG = (
+    "OpenVINOExecutionProvider",
+    {"device_type": "AUTO:GPU,NPU,CPU"},
+)
+
 
 def camera_backends() -> List[Tuple[int, int]]:
     """Return an ordered list of ``(device_index, cv2_backend)`` attempts.

--- a/modules/processors/frame/_onnx_enhancer.py
+++ b/modules/processors/frame/_onnx_enhancer.py
@@ -20,6 +20,11 @@ IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm6
 # Limit concurrent ONNX calls to avoid VRAM exhaustion on multi-face frames
 THREAD_SEMAPHORE = threading.Semaphore(min(max(1, (os.cpu_count() or 1)), 8))
 
+# OpenVINO provider configuration.
+# AUTO:GPU,NPU,CPU lets OpenVINO try the best available device in priority
+# order (Intel GPU → NPU → CPU). 
+OPENVINO_PROVIDER_CONFIG = ("OpenVINOExecutionProvider", {"device_type": "AUTO:GPU,NPU,CPU"})
+
 
 def build_provider_config(providers=None):
     """Wrap raw provider name strings with optimised CUDA / CoreML options.
@@ -51,13 +56,8 @@ def build_provider_config(providers=None):
                 },
             ))
         elif p == "OpenVINOExecutionProvider":
-            # Prefer Intel GPU with FP16 precision when available.
-            # NB: GPU_FP16 is deprecated since OpenVINO 2025.4 — use
-            # device_type="GPU" + precision="FP16" instead.
-            config.append((
-                "OpenVINOExecutionProvider",
-                {"device_type": "GPU", "precision": "FP16"},
-            ))
+            # AUTO lets OpenVINO select the best device
+            config.append(OPENVINO_PROVIDER_CONFIG)
         else:
             config.append(p)
     return config

--- a/modules/processors/frame/_onnx_enhancer.py
+++ b/modules/processors/frame/_onnx_enhancer.py
@@ -50,6 +50,14 @@ def build_provider_config(providers=None):
                     "AllowLowPrecisionAccumulationOnGPU": 1,
                 },
             ))
+        elif p == "OpenVINOExecutionProvider":
+            # Prefer Intel GPU with FP16 precision when available.
+            # NB: GPU_FP16 is deprecated since OpenVINO 2025.4 — use
+            # device_type="GPU" + precision="FP16" instead.
+            config.append((
+                "OpenVINOExecutionProvider",
+                {"device_type": "GPU", "precision": "FP16"},
+            ))
         else:
             config.append(p)
     return config

--- a/modules/processors/frame/_onnx_enhancer.py
+++ b/modules/processors/frame/_onnx_enhancer.py
@@ -14,16 +14,12 @@ import numpy as np
 import onnxruntime
 
 import modules.globals
+from modules.platform_info import OPENVINO_PROVIDER_CONFIG
 
 IS_APPLE_SILICON = platform.system() == "Darwin" and platform.machine() == "arm64"
 
 # Limit concurrent ONNX calls to avoid VRAM exhaustion on multi-face frames
 THREAD_SEMAPHORE = threading.Semaphore(min(max(1, (os.cpu_count() or 1)), 8))
-
-# OpenVINO provider configuration.
-# AUTO:GPU,NPU,CPU lets OpenVINO try the best available device in priority
-# order (Intel GPU → NPU → CPU). 
-OPENVINO_PROVIDER_CONFIG = ("OpenVINOExecutionProvider", {"device_type": "AUTO:GPU,NPU,CPU"})
 
 
 def build_provider_config(providers=None):

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -18,6 +18,7 @@ from modules.utilities import (
 )
 from modules.cluster_analysis import find_closest_centroid
 from modules.gpu_processing import gpu_gaussian_blur, gpu_sharpen, gpu_add_weighted, gpu_resize
+from modules.platform_info import OPENVINO_PROVIDER_CONFIG
 import os
 from collections import deque
 import time
@@ -271,9 +272,6 @@ def get_face_swapper() -> Any:
                         # fastest on modern GPUs (Blackwell/sm_120).
                         providers_config.append(p)
                     elif p == "OpenVINOExecutionProvider":
-                        from modules.processors.frame._onnx_enhancer import (
-                            OPENVINO_PROVIDER_CONFIG,
-                        )
                         providers_config.append(OPENVINO_PROVIDER_CONFIG)
                     else:
                         providers_config.append(p)

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -271,10 +271,10 @@ def get_face_swapper() -> Any:
                         # fastest on modern GPUs (Blackwell/sm_120).
                         providers_config.append(p)
                     elif p == "OpenVINOExecutionProvider":
-                        providers_config.append((
-                            "OpenVINOExecutionProvider",
-                            {"device_type": "GPU", "precision": "FP16"},
-                        ))
+                        from modules.processors.frame._onnx_enhancer import (
+                            OPENVINO_PROVIDER_CONFIG,
+                        )
+                        providers_config.append(OPENVINO_PROVIDER_CONFIG)
                     else:
                         providers_config.append(p)
                 FACE_SWAPPER = insightface.model_zoo.get_model(

--- a/modules/processors/frame/face_swapper.py
+++ b/modules/processors/frame/face_swapper.py
@@ -270,6 +270,11 @@ def get_face_swapper() -> Any:
                         # Use bare provider — ONNX Runtime defaults are
                         # fastest on modern GPUs (Blackwell/sm_120).
                         providers_config.append(p)
+                    elif p == "OpenVINOExecutionProvider":
+                        providers_config.append((
+                            "OpenVINOExecutionProvider",
+                            {"device_type": "GPU", "precision": "FP16"},
+                        ))
                     else:
                         providers_config.append(p)
                 FACE_SWAPPER = insightface.model_zoo.get_model(

--- a/run.py
+++ b/run.py
@@ -39,7 +39,7 @@ if sys.platform == "win32":
             add_openvino_libs_to_path,
         )
         add_openvino_libs_to_path()
-    except (ImportError, FileNotFoundError):
+    except (ImportError, FileNotFoundError, SystemExit):
         pass  # OpenVINO not installed — no-op
 
 # On Linux, pre-load NVIDIA shared libraries (cuDNN, cuBLAS, nvrtc...) shipped

--- a/run.py
+++ b/run.py
@@ -33,14 +33,27 @@ if sys.platform == "win32":
 
     # On Windows, register OpenVINO DLL directories so onnxruntime's
     # OpenVINOExecutionProvider can find openvino.dll.  This must happen
-    # before any ONNX InferenceSession is created.
+    # before any ONNX InferenceSession is created.  Failure is non-fatal:
+    # OpenVINO simply isn't installed, and onnxruntime will fall back to CPU.
     try:
         from onnxruntime.tools.add_openvino_win_libs import (  # type: ignore[import-untyped]  # noqa: E501
             add_openvino_libs_to_path,
         )
         add_openvino_libs_to_path()
-    except (ImportError, FileNotFoundError, SystemExit):
-        pass  # OpenVINO not installed — no-op
+    except ImportError:
+        # onnxruntime build without the OpenVINO tooling module — no-op.
+        pass
+    except FileNotFoundError:
+        # OpenVINO site-packages dir absent — no-op.
+        pass
+    except SystemExit as exc:
+        # add_openvino_libs_to_path() calls sys.exit() when OpenVINO libs
+        # can't be located (e.g. OPENVINO_LIB_PATHS unset).  Log the message
+        # it raised with so the failure is visible, but keep startup alive.
+        print(
+            f"[startup] OpenVINO DLL registration skipped: {exc}",
+            flush=True,
+        )
 
 # On Linux, pre-load NVIDIA shared libraries (cuDNN, cuBLAS, nvrtc...) shipped
 # inside the venv via pip wheels (nvidia-cudnn-cu12, etc.). LD_LIBRARY_PATH

--- a/run.py
+++ b/run.py
@@ -31,6 +31,17 @@ if sys.platform == "win32":
             except (OSError, AttributeError):
                 pass
 
+    # On Windows, register OpenVINO DLL directories so onnxruntime's
+    # OpenVINOExecutionProvider can find openvino.dll.  This must happen
+    # before any ONNX InferenceSession is created.
+    try:
+        from onnxruntime.tools.add_openvino_win_libs import (  # type: ignore[import-untyped]  # noqa: E501
+            add_openvino_libs_to_path,
+        )
+        add_openvino_libs_to_path()
+    except (ImportError, FileNotFoundError):
+        pass  # OpenVINO not installed — no-op
+
 # On Linux, pre-load NVIDIA shared libraries (cuDNN, cuBLAS, nvrtc...) shipped
 # inside the venv via pip wheels (nvidia-cudnn-cu12, etc.). LD_LIBRARY_PATH
 # cannot be set after Python starts, so we use ctypes.CDLL with RTLD_GLOBAL


### PR DESCRIPTION
## Description

Fixes the `openvino.dll` loading issue that prevented ONNX Runtime's OpenVINOExecutionProvider from working on Windows.

### Root Cause

`onnxruntime_providers_openvino.dll` depends on `openvino.dll`, but the OpenVINO Python package installs `openvino.dll` under `site-packages/openvino/libs/` — a directory not on the system `PATH`. When ONNX Runtime attempts to create a session with `OpenVINOExecutionProvider`, the DLL load fails silently and falls back to CPU.

### Changes

| File | Change |
|------|--------|
| `run.py` | Call `add_openvino_libs_to_path()` from `onnxruntime.tools.add_openvino_win_libs` before any ONNX session is created (graceful no-op when OpenVINO is absent, catches SystemExit) |
| `modules/platform_info.py` | Detect `OpenVINOExecutionProvider` in available providers; show "OpenVINO (Intel)" in the banner |
| `modules/core.py` | Add `openvino` to provider priority list; set thread hint to 1 for OpenVINO EP; defer thread evaluation until after providers are assigned |
| `modules/processors/frame/_onnx_enhancer.py` | Extract shared `OPENVINO_PROVIDER_CONFIG` with `AUTO:GPU,NPU,CPU` device priority; used by both enhancer and face_swapper |
| `modules/processors/frame/face_swapper.py` | Import shared OpenVINO config constant |

### PR Review Fixes

This revision addresses feedback from collaborator `kier007` on the original PR:

1. **SystemExit** — `add_openvino_libs_to_path()` can call `sys.exit()` when OpenVINO is absent; now caught alongside `ImportError`/ `FileNotFoundError`
2. **Hard-coded GPU+FP16** — Changed to `AUTO:GPU,NPU,CPU` so OpenVINO selects the best device available; no longer assumes an Intel GPU is present
3. **Thread timing bug** — `suggest_execution_threads()` was evaluated at module load time before `execution_providers` was assigned; now deferred until after `parse_args()` finishes

### Performance

`inswapper_128.onnx` on Intel Arc iGPU + OpenVINO:

| Provider | Device | Latency | FPS |
|----------|--------|---------|-----|
| OpenVINO EP | AUTO:GPU,NPU,CPU | **78 ms** | **12.8 FPS** |
| CPU EP (fallback) | CPU | 786 ms | 1.3 FPS |

### Testing

- [x] `--execution-provider openvino` listed in `--help`
- [x] Banner shows `accelerator: OpenVINO (Intel)`
- [x] Face swapper model loads with `OpenVINOExecutionProvider` active
- [x] Thread hint correctly returns 1 for OpenVINO EP
- [x] Registration is a no-op when OpenVINO is absent (catches SystemExit)
- [x] Removing openvino package gracefully falls back to CPU

## Summary by Sourcery

Handle OpenVINO DLL registration and provider configuration so OpenVINOExecutionProvider works reliably, especially on Windows, and integrate it into provider selection, threading, and UI accelerator labeling.

New Features:
- Add OpenVINOExecutionProvider to the default execution provider priority list and expose it as a selectable accelerator option.
- Introduce a shared OpenVINO provider configuration that uses AUTO:GPU,NPU,CPU for device selection in both the ONNX enhancer and face swapper.

Bug Fixes:
- Ensure suggest_execution_threads() is evaluated only after execution providers are assigned to avoid incorrect thread recommendations.
- Register OpenVINO DLL paths on Windows at startup so onnxruntime can successfully load openvino.dll and avoid silent fallback to CPU.
- Treat missing OpenVINO installation as a no-op by catching ImportError, FileNotFoundError, and SystemExit during DLL registration.

Enhancements:
- Detect OpenVINOExecutionProvider in available ONNX providers and label it as "OpenVINO (Intel)" in the accelerator banner.
- Assign a thread hint of 1 when OpenVINOExecutionProvider is active to better match its performance characteristics.