### PR TITLE
fix: improve macOS support for memory suggestion and video capture

### DIFF
--- a/modules/core.py
+++ b/modules/core.py
@@ -132,8 +132,9 @@ def decode_execution_providers(execution_providers: List[str]) -> List[str]:
 
 
 def suggest_max_memory() -> int:
+    # macOS RLIMIT_DATA cannot be lowered to a finite value; skip by default.
     if platform.system().lower() == 'darwin':
-        return 4
+        return 0
     return 16
 
 

--- a/modules/core.py
+++ b/modules/core.py
@@ -133,7 +133,7 @@ def decode_execution_providers(execution_providers: List[str]) -> List[str]:
 
 def suggest_max_memory() -> int:
     # macOS RLIMIT_DATA cannot be lowered to a finite value; skip by default.
-    if platform.system().lower() == 'darwin':
+    if platform.system() == 'Darwin':
         return 0
     return 16
 
@@ -178,9 +178,9 @@ def limit_resources() -> None:
         for gpu in gpus:
             tensorflow.config.experimental.set_memory_growth(gpu, True)
     # limit memory usage
-    if modules.globals.max_memory:
+    if modules.globals.max_memory is not None and modules.globals.max_memory > 0:
         memory = modules.globals.max_memory * 1024 ** 3
-        if platform.system().lower() == 'windows':
+        if platform.system() == 'Windows':
             import ctypes
             kernel32 = ctypes.windll.kernel32
             kernel32.SetProcessWorkingSetSize(-1, ctypes.c_size_t(memory), ctypes.c_size_t(memory))

--- a/modules/video_capture.py
+++ b/modules/video_capture.py
@@ -73,12 +73,22 @@ class VideoCapturer:
                         continue
             elif platform.system() == "Darwin":
                 # Prefer AVFoundation on macOS. CAP_ANY can pick OBSENSOR and fail.
+                backend_attempts = []
                 for backend in (cv2.CAP_AVFOUNDATION, cv2.CAP_ANY):
-                    self.cap = cv2.VideoCapture(self.device_index, backend)
-                    if self.cap.isOpened():
-                        break
-                    self.cap.release()
-                    self.cap = None
+                    backend_name = "AVFoundation" if backend == cv2.CAP_AVFOUNDATION else "Any"
+                    try:
+                        self.cap = cv2.VideoCapture(self.device_index, backend)
+                        if self.cap.isOpened():
+                            backend_attempts.append(f"{backend_name}: success")
+                            break
+                        self.cap.release()
+                        self.cap = None
+                        backend_attempts.append(f"{backend_name}: opened=False")
+                    except Exception as exc:
+                        self.cap = None
+                        backend_attempts.append(f"{backend_name}: {exc}")
+                if backend_attempts:
+                    print(f"[VideoCapturer] Darwin backend attempts: {'; '.join(backend_attempts)}", flush=True)
             else:
                 # Linux / other Unix-like systems
                 self.cap = cv2.VideoCapture(self.device_index)

--- a/modules/video_capture.py
+++ b/modules/video_capture.py
@@ -71,8 +71,16 @@ class VideoCapturer:
                         self.cap.release()
                     except Exception:
                         continue
+            elif platform.system() == "Darwin":
+                # Prefer AVFoundation on macOS. CAP_ANY can pick OBSENSOR and fail.
+                for backend in (cv2.CAP_AVFOUNDATION, cv2.CAP_ANY):
+                    self.cap = cv2.VideoCapture(self.device_index, backend)
+                    if self.cap.isOpened():
+                        break
+                    self.cap.release()
+                    self.cap = None
             else:
-                # Unix-like systems (Linux/Mac) capture method
+                # Linux / other Unix-like systems
                 self.cap = cv2.VideoCapture(self.device_index)
 
             if not self.cap or not self.cap.isOpened():


### PR DESCRIPTION
This change adjusts the camera initialization path to use platform-specific OpenCV backends and configuration parameters, improving compatibility and reducing capture failures on supported systems.

## Summary by Sourcery

Improve macOS compatibility for video capture and memory usage suggestions.

Bug Fixes:
- Adjust macOS camera initialization to prefer the AVFoundation backend and avoid failing with incompatible backends.
- Update macOS max memory suggestion to skip RLIMIT_DATA adjustments that cannot be safely lowered.