### PR TITLE
fix: replace unverified SSL context; make shell=False explicit in utilities.py

### DIFF
--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -28,7 +28,7 @@ def run_ffmpeg(args: List[str]) -> bool:
     ]
     commands.extend(args)
     try:
-        subprocess.check_output(commands, stderr=subprocess.STDOUT)
+        subprocess.check_output(commands, stderr=subprocess.STDOUT, shell=False)
         return True
     except subprocess.CalledProcessError as error:
         output = error.output.decode(errors="ignore").strip()
@@ -290,10 +290,7 @@ def conditional_download(download_directory_path: str, urls: List[str]) -> None:
             request = urllib.request.Request(url)
             
             # Create a specific SSL context for macOS to avoid globally disabling verification
-            ctx = None
-            if platform.system().lower() == "darwin":
-                ctx = ssl._create_unverified_context()
-                
+            ctx = ssl.create_default_context()
             response = urllib.request.urlopen(request, context=ctx)
             total = int(response.headers.get("Content-Length", 0))
             with tqdm(

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -288,10 +288,9 @@ def conditional_download(download_directory_path: str, urls: List[str]) -> None:
         )
         if not os.path.exists(download_file_path):
             request = urllib.request.Request(url)
-            
-            # Create a specific SSL context for macOS to avoid globally disabling verification
-            ctx = ssl.create_default_context()
-            response = urllib.request.urlopen(request, context=ctx)
+
+            # Use default SSL context for secure certificate verification
+            response = urllib.request.urlopen(request, context=ssl.create_default_context())
             total = int(response.headers.get("Content-Length", 0))
             with tqdm(
                 total=total,

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -289,7 +289,6 @@ def conditional_download(download_directory_path: str, urls: List[str]) -> None:
         if not os.path.exists(download_file_path):
             request = urllib.request.Request(url)
 
-            # Use default SSL context for secure certificate verification
             response = urllib.request.urlopen(request, context=ssl.create_default_context())
             total = int(response.headers.get("Content-Length", 0))
             with tqdm(

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -1,7 +1,6 @@
 import glob
 import mimetypes
 import os
-import platform
 import shutil
 import ssl
 import subprocess


### PR DESCRIPTION
## Summary

Two changes to `modules/utilities.py`:

1. **SSL fix (real improvement):** Replace `ssl._create_unverified_context()` on macOS with `ssl.create_default_context()` on all platforms. The old code disabled TLS certificate verification for all model downloads on macOS, leaving downloads open to MITM. The new code uses Python's default verified context everywhere.

2. **subprocess hardening (defensive clarity):** Add explicit `shell=False` to `subprocess.check_output` in `run_ffmpeg`. This does not change runtime behavior — `commands` was already a list and `shell=False` is the default — but makes the intent visible to future readers and static analyzers.

## What this is not

The original PR description claimed a CWE-78 command injection. That was a scanner false positive: `commands` was already constructed as a list and passed directly to `subprocess.check_output` without `shell=True`, so there was no shell interpretation occurring. The explicit `shell=False` adds clarity, not safety.

## Changes
- `modules/utilities.py`: replace macOS unverified SSL context with `ssl.create_default_context()`; add explicit `shell=False`; remove unused `platform` import (fixes ruff F401 CI failure)

## Verification
- `python -m py_compile modules/utilities.py` passes
- `ruff check modules/utilities.py` passes (no F401)
- Existing test suite passes
- Download flow on macOS: **not yet tested** — flagged by reviewer, worth checking before merge