### PR TITLE
docs: add onnxruntime-openvino/OpenVINO version pairing note

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,22 @@ pip uninstall onnxruntime onnxruntime-openvino
 pip install onnxruntime-openvino==1.21.0
 ```
 
+**Note:** `onnxruntime-openvino` newer than 1.21.0 must be installed together with `openvino`, and the two versions must correspond one-to-one. The supported pairings are:
+
+| onnxruntime-openvino | OpenVINO |
+| --- | --- |
+| 1.24.1 | 2025.4.1 |
+| 1.23.0 | 2025.3 |
+| 1.22.0 | 2025.1 |
+
+```bash
+# Example: onnxruntime-openvino 1.24.1 pairs with OpenVINO 2025.4.1
+pip install openvino==2025.4.1
+pip install onnxruntime-openvino==1.24.1
+```
+
+See the [OpenVINO Execution Provider requirements](https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements) for the full version-mapping details.
+
 2. Usage:
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a note to the **OpenVINO Execution Provider (Intel)** section of the README clarifying that `onnxruntime-openvino` newer than 1.21.0 must be installed together with the `openvino` package, and that the two versions must match one-to-one.

Included supported pairings (per the official onnxruntime docs):

| onnxruntime-openvino | OpenVINO |
| --- | --- |
| 1.24.1 | 2025.4.1 |
| 1.23.0 | 2025.3 |
| 1.22.0 | 2025.1 |

With an install example and a link to the [OpenVINO Execution Provider requirements](https://onnxruntime.ai/docs/execution-providers/OpenVINO-ExecutionProvider.html#requirements).

## Why

Without the matching `openvino` package installed, newer `onnxruntime-openvino` versions fail at runtime (missing OpenVINO DLLs), which is confusing for users following the Intel execution-provider setup.

## Summary by Sourcery

Documentation:
- Add README guidance on one-to-one version pairing between onnxruntime-openvino (>1.21.0) and OpenVINO, including a supported version matrix, install example, and link to official requirements.