### PR TITLE
fix: no cam detected on Arch Linux, use string path for camera capture instead

### DIFF
--- a/modules/ui.py
+++ b/modules/ui.py
@@ -417,7 +417,7 @@ def get_available_cameras() -> Tuple[List[int], List[str]]:
     indices: List[int] = []
     names: List[str] = []
     for i in range(10):
-        cap = cv2.VideoCapture(i)
+        cap = cv2.VideoCapture(f"/dev/video{i}")
         if cap.isOpened():
             indices.append(i)
             names.append(f"Camera {i}")

--- a/modules/video_capture.py
+++ b/modules/video_capture.py
@@ -71,8 +71,9 @@ class VideoCapturer:
                         self.cap.release()
                     except Exception:
                         continue
+            elif platform.system() == "Linux":
+                self.cap = cv2.VideoCapture(f"/dev/video{self.device_index}")
             else:
-                # Unix-like systems (Linux/Mac) capture method
                 self.cap = cv2.VideoCapture(self.device_index)
 
             if not self.cap or not self.cap.isOpened():


### PR DESCRIPTION
fix failure to detect and open camera on linux capture device. 
Use explicit `/dev/videoN` paths instead.
Is a rebased follow up to #1783. it's just @Vito-M's original fix onto `bdeeb3a`