### PR TITLE
Add direct virtual camera output on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,18 @@ python run.py --execution-provider openvino
 -   Use a screen capture tool like OBS to stream.
 -   To change the face, select a new source image.
 
+### Direct Virtual Camera on Linux
+
+Install and configure `v4l2loopback`:
+
+```bash
+./setup-virtual-camera-linux.sh
+```
+
+Enable **Virtual camera**, select the input camera, and click **Live**. Select
+**Deep Live Cam** in the receiving application. The virtual camera is available
+while the Live Preview is running.
+
 ## Download all models in this huggingface link
 - [**Download models here**](https://huggingface.co/hacksider/deep-live-cam/tree/main)
 

--- a/linux/deep-live-cam-v4l2loopback.conf
+++ b/linux/deep-live-cam-v4l2loopback.conf
@@ -1,0 +1,1 @@
+options v4l2loopback video_nr=10 card_label="Deep Live Cam" exclusive_caps=1

--- a/linux/deep-live-cam.modules-load.conf
+++ b/linux/deep-live-cam.modules-load.conf
@@ -1,0 +1,1 @@
+v4l2loopback

--- a/modules/globals.py
+++ b/modules/globals.py
@@ -41,6 +41,7 @@ live_resizable: bool = True
 camera_input_combobox: Any | None = None # Placeholder for UI element if needed
 webcam_preview_running: bool = False
 show_fps: bool = False
+virtual_camera_enabled: bool = False
 
 # System Configuration
 max_memory: int | None = None        # Memory limit in GB? (Needs clarification)

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -75,6 +75,7 @@ from modules.utilities import (
 )
 from modules import imread_unicode
 from modules.video_capture import VideoCapturer
+from modules.virtual_camera import VirtualCameraSink
 
 if platform.system() == "Windows":
     from pygrabber.dshow_graph import FilterGraph
@@ -311,6 +312,7 @@ def save_switch_states():
         "live_resizable": modules.globals.live_resizable,
         "fp_ui": modules.globals.fp_ui,
         "show_fps": modules.globals.show_fps,
+        "virtual_camera_enabled": modules.globals.virtual_camera_enabled,
         "mouth_mask": modules.globals.mouth_mask,
         "show_mouth_mask_box": modules.globals.show_mouth_mask_box,
         "mouth_mask_size": modules.globals.mouth_mask_size,
@@ -338,6 +340,9 @@ def load_switch_states():
         modules.globals.live_resizable = state.get("live_resizable", False)
         modules.globals.fp_ui = state.get("fp_ui", {"face_enhancer": False})
         modules.globals.show_fps = state.get("show_fps", False)
+        modules.globals.virtual_camera_enabled = state.get(
+            "virtual_camera_enabled", False
+        )
         # Mouth mask always starts disabled (slider at 0) on launch,
         # regardless of the persisted value — enable it explicitly each session.
         modules.globals.mouth_mask_size = 0.0
@@ -714,6 +719,15 @@ class MainWindow(QMainWindow):
         self.cb_camera.setToolTip(_("Select which camera to use for live mode"))
         layout.addWidget(self.cb_camera, 1)
 
+        if platform.system() == "Linux":
+            self.sw_virtual_camera = _Switch(
+                _("Virtual camera"),
+                modules.globals.virtual_camera_enabled,
+                _("Publish the processed Live output directly as a Linux webcam"),
+            )
+            self.sw_virtual_camera.toggled.connect(self._on_virtual_camera_toggled)
+            layout.addWidget(self.sw_virtual_camera)
+
         self.btn_live = QPushButton(_("Live"))
         self.btn_live.setEnabled(cam_ok)
         self.btn_live.setToolTip(_("Start real-time face swap using webcam"))
@@ -934,6 +948,12 @@ class MainWindow(QMainWindow):
             modules.globals.source_target_map = []
             _open_live_mapper_dialog(camera_index, modules.globals.source_target_map)
 
+    def _on_virtual_camera_toggled(self, value: bool) -> None:
+        modules.globals.virtual_camera_enabled = value
+        save_switch_states()
+        if _WEBCAM_PREVIEW is not None and _WEBCAM_PREVIEW.isVisible():
+            _WEBCAM_PREVIEW.set_virtual_camera_enabled(value)
+
     def closeEvent(self, event):
         # Treat OS-level close as Destroy click
         self._destroy_cb()
@@ -1033,15 +1053,83 @@ class _CaptureWorker(QThread):
                     pass
 
 
+def _put_latest(target_queue: queue.Queue, frame: np.ndarray) -> None:
+    try:
+        target_queue.put_nowait(frame)
+        return
+    except queue.Full:
+        pass
+    try:
+        target_queue.get_nowait()
+    except queue.Empty:
+        pass
+    try:
+        target_queue.put_nowait(frame)
+    except queue.Full:
+        pass
+
+
+class _VirtualCameraWorker(QThread):
+    status = Signal(str)
+
+    def __init__(
+        self,
+        frame_queue: queue.Queue,
+        width: int,
+        height: int,
+        fps: float,
+    ) -> None:
+        super().__init__()
+        self._queue = frame_queue
+        self._width = width
+        self._height = height
+        self._fps = fps
+        self._stop = threading.Event()
+
+    def stop(self) -> None:
+        self._stop.set()
+
+    def run(self) -> None:
+        try:
+            with VirtualCameraSink(
+                self._width, self._height, self._fps
+            ) as camera:
+                self.status.emit(
+                    f"Virtual camera active: {camera.device} ({camera.backend})"
+                )
+                while not self._stop.is_set():
+                    try:
+                        frame = self._queue.get(timeout=0.05)
+                    except queue.Empty:
+                        continue
+
+                    while True:
+                        try:
+                            frame = self._queue.get_nowait()
+                        except queue.Empty:
+                            break
+                    camera.send(frame)
+        except Exception as exc:
+            self.status.emit(f"Virtual camera unavailable: {exc}")
+
+
 class _ProcessingWorker(QThread):
     """Pulls raw frames, runs detect/swap/enhance, pushes processed frames."""
 
-    def __init__(self, capture_queue, processed_queue, stop_event, camera_fps: float):
+    def __init__(
+        self,
+        capture_queue,
+        processed_queue,
+        stop_event,
+        camera_fps: float,
+        virtual_queue=None,
+    ):
         super().__init__()
         self._cq = capture_queue
         self._pq = processed_queue
         self._stop = stop_event
         self._fps = camera_fps
+        self._vq = virtual_queue
 
     def run(self) -> None:
         frame_processors = get_frame_processors_modules(modules.globals.frame_processors)
@@ -1158,17 +1246,9 @@ class _ProcessingWorker(QThread):
                     cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 0), 2,
                 )
 
-            try:
-                self._pq.put_nowait(temp_frame)
-            except queue.Full:
-                try:
-                    self._pq.get_nowait()
-                except queue.Empty:
-                    pass
-                try:
-                    self._pq.put_nowait(temp_frame)
-                except queue.Full:
-                    pass
+            _put_latest(self._pq, temp_frame)
+            if self._vq is not None:
+                _put_latest(self._vq, temp_frame)
 
 
 class WebcamPreviewWindow(QWidget):
@@ -1183,6 +1263,15 @@ class WebcamPreviewWindow(QWidget):
         self._image_label.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
         layout.addWidget(self._image_label, 1)
 
+        self._capture_queue: queue.Queue = queue.Queue(maxsize=2)
+        self._processed_queue: queue.Queue = queue.Queue(maxsize=2)
+        self._virtual_queue: queue.Queue = queue.Queue(maxsize=1)
+        self._stop_event = threading.Event()
+        self._capture_worker: Optional[_CaptureWorker] = None
+        self._processing_worker: Optional[_ProcessingWorker] = None
+        self._virtual_worker: Optional[_VirtualCameraWorker] = None
+        self._timer: Optional[QTimer] = None
+
         self._cap = VideoCapturer(camera_index)
         if not self._cap.start(PREVIEW_DEFAULT_WIDTH, PREVIEW_DEFAULT_HEIGHT, 60):
             update_status("Failed to start camera")
@@ -1195,18 +1284,24 @@ class WebcamPreviewWindow(QWidget):
             f"{self._cap.actual_height}@{camera_fps:.0f}fps"
         )
 
-        self._capture_queue: queue.Queue = queue.Queue(maxsize=2)
-        self._processed_queue: queue.Queue = queue.Queue(maxsize=2)
-        self._stop_event = threading.Event()
-
         self._capture_worker = _CaptureWorker(
             self._cap, self._capture_queue, self._stop_event
         )
         self._processing_worker = _ProcessingWorker(
-            self._capture_queue, self._processed_queue, self._stop_event, camera_fps
+            self._capture_queue,
+            self._processed_queue,
+            self._stop_event,
+            camera_fps,
+            self._virtual_queue,
         )
         self._capture_worker.start()
         self._processing_worker.start()
+
+        if (
+            platform.system() == "Linux"
+            and modules.globals.virtual_camera_enabled
+        ):
+            self.set_virtual_camera_enabled(True)
 
         # Poll at ~2x camera fps so we never block but also don't burn CPU.
         poll_ms = max(1, min(16, int(500 / max(camera_fps, 1))))
@@ -1225,13 +1320,46 @@ class WebcamPreviewWindow(QWidget):
         bgr_frame = fit_image_to_size(bgr_frame, self.width(), self.height())
         self._image_label.setPixmap(_bgr_to_qpixmap(bgr_frame))
 
+    def set_virtual_camera_enabled(self, enabled: bool) -> None:
+        if enabled:
+            if self._virtual_worker is not None and self._virtual_worker.isRunning():
+                return
+            self._virtual_worker = _VirtualCameraWorker(
+                self._virtual_queue,
+                self._cap.actual_width or PREVIEW_DEFAULT_WIDTH,
+                self._cap.actual_height or PREVIEW_DEFAULT_HEIGHT,
+                self._cap.actual_fps or 30.0,
+            )
+            self._virtual_worker.status.connect(update_status)
+            self._virtual_worker.start()
+            return
+
+        self._stop_virtual_camera()
+        update_status("Virtual camera stopped")
+
+    def _stop_virtual_camera(self) -> None:
+        worker = self._virtual_worker
+        self._virtual_worker = None
+        if worker is None:
+            return
+        worker.stop()
+        worker.wait(2000)
+        while True:
+            try:
+                self._virtual_queue.get_nowait()
+            except queue.Empty:
+                break
+
     def closeEvent(self, event) -> None:
+        self._stop_virtual_camera()
         self._stop_event.set()
         try:
             self._timer.stop()
         except Exception:
             pass
         for worker in (self._capture_worker, self._processing_worker):
+            if worker is None:
+                continue
             try:
                 worker.wait(2000)
             except Exception:

--- a/modules/ui.py
+++ b/modules/ui.py
@@ -1071,6 +1071,7 @@ def _put_latest(target_queue: queue.Queue, frame: np.ndarray) -> None:
 
 class _VirtualCameraWorker(QThread):
     status = Signal(str)
+    failed = Signal(str)
 
     def __init__(
         self,
@@ -1110,7 +1111,7 @@ class _VirtualCameraWorker(QThread):
                             break
                     camera.send(frame)
         except Exception as exc:
-            self.status.emit(f"Virtual camera unavailable: {exc}")
+            self.failed.emit(f"Virtual camera unavailable: {exc}")
 
 
 class _ProcessingWorker(QThread):
@@ -1324,18 +1325,31 @@ class WebcamPreviewWindow(QWidget):
         if enabled:
             if self._virtual_worker is not None and self._virtual_worker.isRunning():
                 return
-            self._virtual_worker = _VirtualCameraWorker(
+            worker = _VirtualCameraWorker(
                 self._virtual_queue,
                 self._cap.actual_width or PREVIEW_DEFAULT_WIDTH,
                 self._cap.actual_height or PREVIEW_DEFAULT_HEIGHT,
                 self._cap.actual_fps or 30.0,
             )
-            self._virtual_worker.status.connect(update_status)
-            self._virtual_worker.start()
+            worker.status.connect(update_status)
+            worker.failed.connect(self._on_virtual_camera_failed)
+            self._virtual_worker = worker
+            worker.start()
             return
 
         self._stop_virtual_camera()
         update_status("Virtual camera stopped")
+
+    def _on_virtual_camera_failed(self, message: str) -> None:
+        if self.sender() is not self._virtual_worker:
+            return
+
+        self._stop_virtual_camera()
+        modules.globals.virtual_camera_enabled = False
+        save_switch_states()
+        if _MAIN is not None:
+            _MAIN.sw_virtual_camera.setChecked(False)
+        update_status(message)
 
     def _stop_virtual_camera(self) -> None:
         worker = self._virtual_worker

--- a/modules/virtual_camera.py
+++ b/modules/virtual_camera.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import cv2
+import numpy as np
+
+
+VIRTUAL_CAMERA_LABEL = "Deep Live Cam"
+VIRTUAL_CAMERA_DEVICE_ENV = "DEEP_LIVE_CAM_VIRTUAL_DEVICE"
+
+
+class VirtualCameraError(RuntimeError):
+    pass
+
+
+def find_virtual_camera_device(
+    sys_class_root: Path | str = "/sys/class/video4linux",
+    dev_root: Path | str = "/dev",
+    label: str = VIRTUAL_CAMERA_LABEL,
+) -> Optional[str]:
+    configured = os.environ.get(VIRTUAL_CAMERA_DEVICE_ENV)
+    if configured:
+        return configured
+
+    sys_class_root = Path(sys_class_root)
+    dev_root = Path(dev_root)
+    wanted = label.casefold()
+    for name_file in sorted(sys_class_root.glob("video*/name")):
+        try:
+            device_name = name_file.read_text(encoding="utf-8").strip()
+        except OSError:
+            continue
+        if device_name.casefold() != wanted:
+            continue
+        device_path = dev_root / name_file.parent.name
+        if device_path.exists():
+            return str(device_path)
+    return None
+
+
+class VirtualCameraSink:
+    def __init__(
+        self,
+        width: int,
+        height: int,
+        fps: float,
+        device: Optional[str] = None,
+    ) -> None:
+        try:
+            import pyvirtualcam
+        except ImportError as exc:
+            raise VirtualCameraError(
+                "pyvirtualcam is missing; reinstall the project requirements."
+            ) from exc
+
+        self.width = max(1, int(width))
+        self.height = max(1, int(height))
+        self.fps = max(1.0, float(fps))
+        self.device = device or find_virtual_camera_device()
+        if self.device is None:
+            raise VirtualCameraError(
+                "No 'Deep Live Cam' virtual camera was found. Run "
+                "./setup-virtual-camera-linux.sh first."
+            )
+
+        try:
+            self._camera = pyvirtualcam.Camera(
+                width=self.width,
+                height=self.height,
+                fps=self.fps,
+                fmt=pyvirtualcam.PixelFormat.YUYV,
+                device=self.device,
+                print_fps=False,
+            )
+        except Exception as exc:
+            raise VirtualCameraError(
+                f"Could not open virtual camera {self.device}: {exc}"
+            ) from exc
+
+    @property
+    def backend(self) -> str:
+        return self._camera.backend
+
+    def send(self, bgr_frame: np.ndarray) -> None:
+        frame = bgr_frame
+        if frame.shape[:2] != (self.height, self.width):
+            frame = cv2.resize(
+                frame,
+                (self.width, self.height),
+                interpolation=cv2.INTER_LINEAR,
+            )
+        if frame.dtype != np.uint8:
+            frame = np.clip(frame, 0, 255).astype(np.uint8)
+        frame = np.ascontiguousarray(frame)
+        yuyv_frame = cv2.cvtColor(frame, cv2.COLOR_BGR2YUV_YUYV)
+        self._camera.send(yuyv_frame)
+
+    def close(self) -> None:
+        self._camera.close()
+
+    def __enter__(self) -> "VirtualCameraSink":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ opennsfw2==0.18.0
 keras>=3.0.0
 protobuf>=6.33.5,<8
 pygrabber; sys_platform == 'win32'
+pyvirtualcam>=0.15,<0.16; sys_platform == 'linux'

--- a/setup-virtual-camera-linux.sh
+++ b/setup-virtual-camera-linux.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+if command -v omarchy >/dev/null 2>&1; then
+    omarchy pkg add v4l2loopback-dkms v4l2loopback-utils
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -S --needed v4l2loopback-dkms v4l2loopback-utils
+elif command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y v4l2loopback-dkms v4l2loopback-utils
+else
+    echo "Unsupported distribution: install v4l2loopback and its utilities first." >&2
+    exit 1
+fi
+
+sudo install -Dm644 \
+    "$project_dir/linux/deep-live-cam-v4l2loopback.conf" \
+    /etc/modprobe.d/deep-live-cam-v4l2loopback.conf
+sudo install -Dm644 \
+    "$project_dir/linux/deep-live-cam.modules-load.conf" \
+    /etc/modules-load.d/deep-live-cam.conf
+
+if [[ -e /dev/video10 ]]; then
+    device_name="$(< /sys/class/video4linux/video10/name)"
+    if [[ "$device_name" != "Deep Live Cam" ]]; then
+        echo "/dev/video10 is already used by $device_name." >&2
+        exit 1
+    fi
+else
+    if [[ -d /sys/module/v4l2loopback ]]; then
+        echo "v4l2loopback is already loaded with different options." >&2
+        echo "Close programs using virtual cameras, then reboot or reload the module." >&2
+        exit 1
+    fi
+    sudo modprobe v4l2loopback
+fi
+
+echo "Deep Live Cam virtual camera ready at /dev/video10."

--- a/tests/test_virtual_camera.py
+++ b/tests/test_virtual_camera.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from modules.virtual_camera import VirtualCameraSink, find_virtual_camera_device
+
+
+class VirtualCameraTests(unittest.TestCase):
+    def test_finds_device_by_label(self):
+        with tempfile.TemporaryDirectory() as directory, patch.dict(
+            os.environ, {}, clear=True
+        ):
+            root = Path(directory)
+            sys_class = root / "sys"
+            device_dir = sys_class / "video10"
+            device_dir.mkdir(parents=True)
+            (device_dir / "name").write_text("Deep Live Cam\n", encoding="utf-8")
+            dev_root = root / "dev"
+            dev_root.mkdir()
+            (dev_root / "video10").touch()
+
+            self.assertEqual(
+                find_virtual_camera_device(sys_class, dev_root),
+                str(dev_root / "video10"),
+            )
+
+    def test_resizes_and_converts_frames(self):
+        sent = []
+
+        class FakeCamera:
+            backend = "test"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+            def send(self, frame):
+                sent.append(frame)
+
+            def close(self):
+                pass
+
+        fake_module = types.SimpleNamespace(
+            Camera=FakeCamera,
+            PixelFormat=types.SimpleNamespace(YUYV="YUYV"),
+        )
+        with patch.dict(sys.modules, {"pyvirtualcam": fake_module}):
+            sink = VirtualCameraSink(640, 360, 30, device="/dev/video10")
+            sink.send(np.ones((180, 320, 3), dtype=np.float32) * 300)
+            sink.close()
+
+        self.assertEqual(sent[0].shape, (360, 640, 2))
+        self.assertEqual(sent[0].dtype, np.uint8)
+        self.assertTrue(sent[0].flags.c_contiguous)
+        self.assertEqual(tuple(sent[0][0, 0]), (235, 128))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_virtual_camera.py
+++ b/tests/test_virtual_camera.py
@@ -3,11 +3,13 @@ import sys
 import tempfile
 import types
 import unittest
+from queue import Queue
 from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
 
+from modules import ui
 from modules.virtual_camera import VirtualCameraSink, find_virtual_camera_device
 
 
@@ -58,6 +60,67 @@ class VirtualCameraTests(unittest.TestCase):
         self.assertEqual(sent[0].dtype, np.uint8)
         self.assertTrue(sent[0].flags.c_contiguous)
         self.assertEqual(tuple(sent[0][0, 0]), (235, 128))
+
+    def test_worker_reports_startup_failure(self):
+        messages = []
+        worker = ui._VirtualCameraWorker(Queue(), 640, 360, 30)
+        worker.failed.connect(messages.append)
+
+        with patch.object(
+            ui,
+            "VirtualCameraSink",
+            side_effect=RuntimeError("device unavailable"),
+        ):
+            worker.run()
+
+        self.assertEqual(
+            messages,
+            ["Virtual camera unavailable: device unavailable"],
+        )
+
+    def test_worker_failure_resets_ui_and_saved_state(self):
+        failed_worker = object()
+
+        class Preview:
+            _virtual_worker = failed_worker
+
+            def sender(self):
+                return failed_worker
+
+            def _stop_virtual_camera(self):
+                self._virtual_worker = None
+
+        class Switch:
+            checked = True
+
+            def setChecked(self, value):
+                self.checked = value
+
+        switch = Switch()
+        main = types.SimpleNamespace(sw_virtual_camera=switch)
+        preview = Preview()
+
+        with patch.object(ui, "_MAIN", main), patch.object(
+            ui.modules.globals,
+            "virtual_camera_enabled",
+            True,
+        ), patch.object(ui, "save_switch_states") as save_states, patch.object(
+            ui,
+            "update_status",
+        ) as update_status:
+            ui.WebcamPreviewWindow._on_virtual_camera_failed(
+                preview,
+                "Virtual camera unavailable: device unavailable",
+            )
+
+            self.assertFalse(ui.modules.globals.virtual_camera_enabled)
+
+        self.assertIsNone(preview._virtual_worker)
+        self.assertFalse(switch.checked)
+        save_states.assert_called_once_with()
+        update_status.assert_called_once_with(
+            "Virtual camera unavailable: device unavailable"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
adds optional v4l2 output for processed live frames using a non-blocking writer. UI toggle & setup script + test.
I wanted this instead of having to rely on OBS virtual cam (or similar). much nicer solution

## Summary by Sourcery

Add optional Linux-only virtual camera output for live processed frames and document how to set it up.

New Features:
- Expose a Virtual camera toggle in the live camera UI on Linux to publish processed live output as a webcam via v4l2loopback.
- Introduce a VirtualCameraSink abstraction to stream processed frames to a v4l2loopback-backed device using pyvirtualcam.
- Add a setup script and kernel/module configuration for creating a labeled v4l2loopback device on Linux.

Enhancements:
- Refine live preview frame queue handling to always keep and forward the latest processed frame, including for virtual camera output.

Build:
- Add a Linux-only dependency on pyvirtualcam for virtual camera support.

Deployment:
- Install v4l2loopback configuration files and module-load settings via a helper script to provision the virtual camera device.

Documentation:
- Document Linux virtual camera usage and setup steps in the README.

Tests:
- Add unit tests for virtual camera device discovery and frame format handling.