### PR TITLE
docs: align GFPGAN model filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ cd Deep-Live-Cam
 
 **3. Download the Models**
 
-1. [GFPGANv1.4](https://huggingface.co/hacksider/deep-live-cam/resolve/main/GFPGANv1.4.onnx)
+1. [gfpgan-1024.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/gfpgan-1024.onnx)
 2. [inswapper\_128\_fp16.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx)
 
 Place these files in the "**models**" folder.

--- a/models/instructions.txt
+++ b/models/instructions.txt
@@ -1,4 +1,4 @@
 just put the models in this folder -
 
 https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx?download=true
-https://github.com/TencentARC/GFPGAN/releases/download/v1.3.4/GFPGANv1.4.pth
+https://huggingface.co/hacksider/deep-live-cam/resolve/main/gfpgan-1024.onnx?download=true


### PR DESCRIPTION
## Summary
- update the README model download entry to the exact `gfpgan-1024.onnx` filename loaded by the face enhancer
- update `models/instructions.txt` to use the same Hugging Face model URL
- remove stale `GFPGANv1.4.onnx` and `.pth` instructions that do not match the current loader

## Validation
- `git diff --check`
- verified `modules/processors/frame/face_enhancer.py` loads `gfpgan-1024.onnx`
- documentation-only change; no runtime or dependency behavior changed

## Summary by Sourcery

Documentation:
- Update README and model instructions to reference the gfpgan-1024.onnx file and URL instead of outdated GFPGANv1.4 artifacts.