### PR TITLE
fix(ui): clean up tooltip on widget destroy

### DIFF
--- a/modules/ui_tooltip.py
+++ b/modules/ui_tooltip.py
@@ -1,5 +1,7 @@
 """Lightweight hover tooltip for CustomTkinter widgets."""
 
+from tkinter import TclError
+
 import customtkinter as ctk
 
 
@@ -19,6 +21,7 @@ class ToolTip:
 
         widget.bind("<Enter>", self._schedule_show, add="+")
         widget.bind("<Leave>", self._hide, add="+")
+        widget.bind("<Destroy>", self._on_destroy, add="+")
 
     def _schedule_show(self, event=None):
         self._cancel()
@@ -65,10 +68,21 @@ class ToolTip:
     def _hide(self, event=None):
         self._cancel()
         if self._tooltip_window is not None:
-            self._tooltip_window.destroy()
+            try:
+                self._tooltip_window.destroy()
+            except TclError:
+                pass
             self._tooltip_window = None
+
+    def _on_destroy(self, event=None):
+        """Release callbacks and windows when the owner widget is destroyed."""
+        self._hide()
 
     def _cancel(self):
         if self._after_id is not None:
-            self._widget.after_cancel(self._after_id)
-            self._after_id = None
+            try:
+                self._widget.after_cancel(self._after_id)
+            except TclError:
+                pass
+            finally:
+                self._after_id = None

--- a/tests/test_ui_tooltip.py
+++ b/tests/test_ui_tooltip.py
@@ -1,0 +1,68 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+class FakeTclError(Exception):
+    pass
+
+
+class FakeWidget:
+    def __init__(self):
+        self.bindings = {}
+        self.after_cancel_calls = []
+
+    def bind(self, sequence, callback, add=None):
+        self.bindings[sequence] = (callback, add)
+
+    def after_cancel(self, after_id):
+        self.after_cancel_calls.append(after_id)
+        raise FakeTclError("widget has been destroyed")
+
+
+class FakeTooltipWindow:
+    def destroy(self):
+        raise FakeTclError("tooltip has been destroyed")
+
+
+def _load_tooltip_module():
+    cv2 = types.ModuleType("cv2")
+    cv2.IMREAD_COLOR = 1
+    numpy = types.ModuleType("numpy")
+    customtkinter = types.ModuleType("customtkinter")
+    customtkinter.CTkBaseClass = object
+    tkinter = types.ModuleType("tkinter")
+    tkinter.TclError = FakeTclError
+    with patch.dict(
+        sys.modules,
+        {
+            "cv2": cv2,
+            "numpy": numpy,
+            "customtkinter": customtkinter,
+            "tkinter": tkinter,
+        },
+    ):
+        sys.modules.pop("modules.ui_tooltip", None)
+        return importlib.import_module("modules.ui_tooltip")
+
+
+class ToolTipDestroyTests(unittest.TestCase):
+    def test_destroy_binding_cleans_pending_callback_and_window(self):
+        tooltip_module = _load_tooltip_module()
+        widget = FakeWidget()
+        tooltip = tooltip_module.ToolTip(widget, "text")
+        tooltip._after_id = "after-1"
+        tooltip._tooltip_window = FakeTooltipWindow()
+
+        self.assertIn("<Destroy>", widget.bindings)
+        tooltip._on_destroy()
+
+        self.assertEqual(widget.after_cancel_calls, ["after-1"])
+        self.assertIsNone(tooltip._after_id)
+        self.assertIsNone(tooltip._tooltip_window)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Bind ToolTip owners to <Destroy> so delayed callbacks and popup windows do not outlive their widgets. Cleanup tolerates already-destroyed Tk objects. Adds a focused headless lifecycle test. This follows the lifecycle concern in Sourcery review https://github.com/hacksider/Deep-Live-Cam/pull/1689. Validation: python3 -m py_compile modules/ui_tooltip.py tests/test_ui_tooltip.py; PYTHONPATH=. pytest -q tests/test_ui_tooltip.py tests/test_face_analyser_get_one_face.py tests/test_core_map_faces_fallback.py. The separate theme-color suggestion remains out of scope.

## Summary by Sourcery

Ensure UI tooltips are safely cleaned up when their owner widgets are destroyed to prevent lingering callbacks and windows.

Bug Fixes:
- Prevent tooltip popup windows and delayed callbacks from outliving their destroyed owner widgets by binding cleanup to the widget destroy event.
- Handle already-destroyed Tk objects gracefully when cancelling pending callbacks and destroying tooltip windows.

Tests:
- Add a focused headless unit test verifying that tooltip destroy handling cancels pending callbacks and clears tooltip windows without errors.