### PR TITLE
fix: fall back when ffprobe fps detection fails

### DIFF
--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -52,11 +52,17 @@ def detect_fps(target_path: str) -> float:
         "default=noprint_wrappers=1:nokey=1",
         target_path,
     ]
-    output = subprocess.check_output(command).decode().strip().split("/")
     try:
+        output = subprocess.check_output(command, encoding="utf-8").strip().split("/")
         numerator, denominator = map(int, output)
         return numerator / denominator
-    except Exception:
+    except (
+        subprocess.CalledProcessError,
+        OSError,
+        UnicodeDecodeError,
+        ValueError,
+        ZeroDivisionError,
+    ):
         pass
     return 30.0
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+import unittest
+from unittest import mock
+
+
+def _load_utilities_module():
+    fake_globals = types.ModuleType("modules.globals")
+    fake_globals.execution_threads = 0
+    fake_globals.log_level = "error"
+    fake_globals.execution_providers = []
+    fake_globals.video_encoder = "libx264"
+    fake_globals.video_quality = 23
+
+    fake_cv2 = types.ModuleType("cv2")
+    fake_cv2.IMREAD_COLOR = 1
+    fake_cv2.imdecode = lambda *args, **kwargs: None
+    fake_cv2.imencode = lambda *args, **kwargs: (True, types.SimpleNamespace(tofile=lambda *_: None))
+
+    fake_numpy = types.ModuleType("numpy")
+    fake_numpy.uint8 = int
+    fake_numpy.fromfile = lambda *args, **kwargs: b""
+
+    fake_tqdm = types.ModuleType("tqdm")
+    fake_tqdm.tqdm = lambda iterable, *args, **kwargs: iterable
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "modules.globals": fake_globals,
+            "cv2": fake_cv2,
+            "numpy": fake_numpy,
+            "tqdm": fake_tqdm,
+        },
+        clear=False,
+    ):
+        sys.modules.pop("modules", None)
+        sys.modules.pop("modules.utilities", None)
+        return importlib.import_module("modules.utilities")
+
+
+class DetectFpsTests(unittest.TestCase):
+    def test_detect_fps_returns_fraction_result(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(utilities.subprocess, "check_output", return_value="30000/1001\n") as check:
+            self.assertAlmostEqual(utilities.detect_fps("demo.mp4"), 30000 / 1001)
+
+        check.assert_called_once_with(mock.ANY, encoding="utf-8")
+
+    def test_detect_fps_falls_back_on_command_failure(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(
+            utilities.subprocess,
+            "check_output",
+            side_effect=utilities.subprocess.CalledProcessError(1, ["ffprobe"]),
+        ):
+            self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
+
+    def test_detect_fps_falls_back_on_malformed_output(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(utilities.subprocess, "check_output", return_value="not-a-fraction"):
+            self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
+
+    def test_detect_fps_falls_back_on_zero_denominator(self) -> None:
+        utilities = _load_utilities_module()
+
+        with mock.patch.object(utilities.subprocess, "check_output", return_value="30/0"):
+            self.assertEqual(utilities.detect_fps("demo.mp4"), 30.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep `ffprobe` FPS execution and parsing inside the guarded path
- request UTF-8 text output and return the existing `30.0` fallback for command, decoding, malformed-output, and zero-denominator failures
- add focused mocked tests for valid fractions and each fallback path

## Context

This is an independent follow-up to [#1778](https://github.com/hacksider/Deep-Live-Cam/pull/1778), which was closed without merge. It preserves the existing API and fallback behavior while covering the failure boundary.

## Validation

- `python3 -m unittest tests/test_utilities.py` (4 tests)
- `python3 -m py_compile modules/utilities.py tests/test_utilities.py`
- `git diff --check`

## Summary by Sourcery

Improve video FPS detection robustness while preserving the existing 30.0 FPS fallback behavior.

Bug Fixes:
- Ensure detect_fps gracefully falls back to 30.0 FPS when ffprobe invocation, decoding, parsing, or zero-denominator issues occur.

Enhancements:
- Request UTF-8 decoding for ffprobe output in detect_fps to handle text output consistently.

Tests:
- Add isolated unit tests for detect_fps that cover successful fraction parsing and each fallback scenario using mocked subprocess output.