### PR TITLE
docs: chnage dependency version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ pip install git+https://github.com/TencentARC/GFPGAN.git@master
 ```bash
 pip install -U torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128
 pip uninstall onnxruntime onnxruntime-gpu
-pip install onnxruntime-gpu==1.21.0
+pip install onnxruntime-gpu==1.26.0
 ```
 
 3. Usage:


### PR DESCRIPTION
Hey, the docs state an outdated version for `onnxruntime-gpu` in the CUDA (windows) section.

I stumbled about this issue when trying to install the thing and the dependency failed.

You requirements.txt also states:
`onnxruntime-gpu==1.26.0; sys_platform != 'darwin'`

So i guess this is just a minor mismatch in the docs.

## Summary by Sourcery

Align the documented Windows CUDA dependency version with the supported onnxruntime-gpu release.

Bug Fixes:
- Update the Windows CUDA installation instructions to use the current onnxruntime-gpu 1.26.0 dependency version.

Documentation:
- Correct the documented onnxruntime-gpu version in the README to match the project requirements.