### PR TITLE
fix: keep DirectML face analysis on CPU

### DIFF
--- a/modules/face_analyser.py
+++ b/modules/face_analyser.py
@@ -26,13 +26,10 @@ def get_face_analyser() -> Any:
         with FACE_ANALYSER_LOCK:
             # Double-check after acquiring lock
             if FACE_ANALYSER is None:
-                from modules.processors.frame._onnx_enhancer import (
-                    build_provider_config,
-                )
                 from modules.model_downloader import ensure_insightface_pack
 
                 ensure_insightface_pack('buffalo_l')
-                providers = build_provider_config()
+                providers = build_face_analyser_provider_config()
                 FACE_ANALYSER = insightface.app.FaceAnalysis(
                     name='buffalo_l',
                     providers=providers,
@@ -41,6 +38,24 @@ def get_face_analyser() -> Any:
                 FACE_ANALYSER.prepare(ctx_id=0, det_size=DET_SIZE)
                 _optimize_det_model(FACE_ANALYSER, providers)
     return FACE_ANALYSER
+
+
+def build_face_analyser_provider_config():
+    """Build provider config for InsightFace analysis models.
+
+    DirectML can still be used by the swapper/enhancer pipeline, but running
+    InsightFace detection/recognition on DirectML at the same time has been
+    reported to crash on AMD systems. Keep analysis on CPU for DirectML runs
+    while preserving the existing provider configuration for all other modes.
+    """
+    if _is_dml():
+        return ["CPUExecutionProvider"]
+
+    from modules.processors.frame._onnx_enhancer import (
+        build_provider_config,
+    )
+
+    return build_provider_config()
 
 
 def _optimize_det_model(fa: Any, providers) -> None:

--- a/tests/test_face_analyser_provider_config.py
+++ b/tests/test_face_analyser_provider_config.py
@@ -1,0 +1,80 @@
+import importlib
+import sys
+import types
+import unittest
+
+
+def _install_import_stubs():
+    sys.modules.setdefault(
+        "insightface",
+        types.SimpleNamespace(app=types.SimpleNamespace(FaceAnalysis=object)),
+    )
+    sys.modules.setdefault(
+        "cv2",
+        types.SimpleNamespace(
+            IMREAD_COLOR=1,
+            imread=lambda *_args, **_kwargs: None,
+            imdecode=lambda *_args, **_kwargs: None,
+            imencode=lambda *_args, **_kwargs: (
+                True,
+                types.SimpleNamespace(tofile=lambda *_a, **_k: None),
+            ),
+        ),
+    )
+    sys.modules.setdefault(
+        "numpy",
+        types.SimpleNamespace(uint8=object, fromfile=lambda *_args, **_kwargs: b""),
+    )
+    sys.modules.setdefault(
+        "tqdm",
+        types.SimpleNamespace(tqdm=lambda iterable, **_kwargs: iterable),
+    )
+    sys.modules["modules.typing"] = types.SimpleNamespace(Frame=object)
+    sys.modules["modules.cluster_analysis"] = types.SimpleNamespace(
+        find_cluster_centroids=lambda *args, **kwargs: [],
+        find_closest_centroid=lambda *args, **kwargs: (0, None),
+    )
+    sys.modules["modules.utilities"] = types.SimpleNamespace(
+        get_temp_directory_path=lambda path: path,
+        create_temp=lambda path: None,
+        extract_frames=lambda path: None,
+        clean_temp=lambda path: None,
+        get_temp_frame_paths=lambda path: [],
+    )
+    sys.modules["modules.processors.frame._onnx_enhancer"] = types.SimpleNamespace(
+        build_provider_config=lambda providers=None: list(
+            providers
+            if providers is not None
+            else sys.modules["modules.globals"].execution_providers
+        ),
+    )
+
+
+def _load_face_analyser():
+    _install_import_stubs()
+    sys.modules.pop("modules.face_analyser", None)
+    return importlib.import_module("modules.face_analyser")
+
+
+class FaceAnalyserProviderConfigTests(unittest.TestCase):
+    def test_uses_cpu_provider_for_directml_face_analysis(self):
+        face_analyser = _load_face_analyser()
+        face_analyser.modules.globals.execution_providers = ["DmlExecutionProvider"]
+
+        self.assertEqual(
+            face_analyser.build_face_analyser_provider_config(),
+            ["CPUExecutionProvider"],
+        )
+
+    def test_preserves_existing_provider_config_for_non_directml(self):
+        face_analyser = _load_face_analyser()
+        face_analyser.modules.globals.execution_providers = ["CUDAExecutionProvider"]
+
+        self.assertEqual(
+            face_analyser.build_face_analyser_provider_config(),
+            ["CUDAExecutionProvider"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep InsightFace face analysis on `CPUExecutionProvider` for DirectML runs
- preserve the configured providers for CUDA, CoreML, and CPU runs
- add focused unit coverage for the provider-selection boundary

## Why

DirectML users reported freezes and crashes during live preview or face swap on AMD systems. InsightFace detection and recognition do not need to run on DirectML, and isolating them on CPU avoids the reported provider conflict while leaving the rest of the DirectML pipeline unchanged.

Refs #1690. This supersedes the same-scope closed, unmerged PR #1807 with a fresh patch against current `main`.

## Validation

- `python3 -m unittest tests.test_face_analyser_provider_config tests.test_face_analyser_get_one_face -v`
- `python3 -m py_compile modules/face_analyser.py tests/test_face_analyser_provider_config.py`
- `ruff check modules/face_analyser.py tests/test_face_analyser_provider_config.py`
- `git diff --check`

## Branch note

The repository contribution guide mentions an initial `premain` branch, but the upstream repository currently has no `premain` branch. The contributor fork''s `premain` is already occupied by another open PR, so this branch keeps the `premain-` prefix and targets the repository''s current default branch, `main`.

## Summary by Sourcery

Keep DirectML face analysis on CPU while leaving the rest of the provider configuration unchanged.

Bug Fixes:
- Keep InsightFace face analysis on the CPU execution provider during DirectML runs to prevent AMD-related freezes and crashes.
- Preserve existing execution-provider configuration for CUDA, CoreML, and CPU runs.

Enhancements:
- Centralize InsightFace provider selection in a dedicated configuration boundary.

Tests:
- Add focused unit coverage for DirectML and non-DirectML face-analysis provider selection.