### PR TITLE
docs: use the supported DirectML provider token

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ pip install onnxruntime-directml==1.21.0
 2. Usage:
 
 ```bash
-python run.py --execution-provider directml
+python run.py --execution-provider dml
 ```
 
 **OpenVINO™ Execution Provider (Intel)**


### PR DESCRIPTION
## Summary
- update the README DirectML usage example to use `dml`, the provider token accepted by the current CLI

## Validation
- `git diff --check`
- `python3 -m py_compile run.py modules/core.py`

Fixes the documentation mismatch tracked by #1292. This is a docs-only change; the existing contribution hardware checklist is not applicable to runtime behavior changes.

## Summary by Sourcery

Documentation:
- Update the README DirectML usage example to use the supported `dml` execution-provider token.