### PR TITLE
docs: align default face swapper model name

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ cd Deep-Live-Cam
 **3. Download the Models**
 
 1. [gfpgan-1024.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/gfpgan-1024.onnx)
-2. [inswapper\_128\_fp16.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx)
+2. [inswapper\_128.onnx](https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128.onnx)
+
+The application also accepts `inswapper_128_fp16.onnx` when an FP16-capable GPU is available.
 
 Place these files in the "**models**" folder.
 

--- a/models/instructions.txt
+++ b/models/instructions.txt
@@ -1,4 +1,4 @@
 just put the models in this folder -
 
-https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128_fp16.onnx?download=true
+https://huggingface.co/hacksider/deep-live-cam/resolve/main/inswapper_128.onnx?download=true
 https://huggingface.co/hacksider/deep-live-cam/resolve/main/gfpgan-1024.onnx?download=true


### PR DESCRIPTION
## Summary
- make `inswapper_128.onnx` the documented default download
- note that `inswapper_128_fp16.onnx` remains accepted for FP16-capable GPUs
- update `models/instructions.txt` to the same default filename

## Validation
- `git diff --check`
- verified the Hugging Face default-model URL returns HTTP 302

The current face-swapper code accepts both variants and prefers the FP32 model outside CUDA. This aligns the setup docs with that behavior and addresses the filename confusion in #1628/#1633.

## Summary by Sourcery

Align face-swapper setup documentation with the model filenames supported by the application.

Enhancements:
- Align the documented default face-swapper model with the FP32 filename preferred by the application while documenting the FP16 alternative for compatible GPUs.

Documentation:
- Update the README and model instructions to use `inswapper_128.onnx` as the default download.