### PR TITLE
ci: configure Dependabot for root requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- add a minimal Dependabot configuration for the root pip project
- explicitly point Dependabot at `/` so it tracks the repository `requirements.txt`
- check for weekly dependency updates

## Validation
- parsed `.github/dependabot.yml` with PyYAML
- `git diff --check`

This is configuration-only and does not alter runtime or hardware behavior.

## Summary by Sourcery

CI:
- Configure Dependabot to monitor the root pip project and check for dependency updates weekly.